### PR TITLE
feat: add 2BN0 three-gang switch support

### DIFF
--- a/custom_components/huawei_smarthome/hwiotdevices/electrical/2BN0.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/electrical/2BN0.py
@@ -1,0 +1,291 @@
+"""Explicit Huawei SmartHome model for the 2BN0 three-gang wall switch."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+import json
+from typing import Any
+import uuid
+
+from ...const import OBSERVED_MQTT_FILTER
+from ...domain.models import RemoteDeviceDescriptor
+from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
+
+PROD_ID = "2BN0"
+HA_PLATFORM = "switch"
+MANUFACTURER_NAME = "领普科技"
+PROFILE_MODEL = "Q4S-BLE-W3(HW)"
+COMMAND_ACK_TIMEOUT = 10.0
+
+SERVICE_SWITCH = "switch"
+CHANNEL_SERVICE_IDS = ("switch1", "switch2", "switch3")
+STATE_SERVICES = frozenset({SERVICE_SWITCH, *CHANNEL_SERVICE_IDS})
+COMMAND_SERVICES = STATE_SERVICES
+SWITCH_NAMES = {
+    "switch1": "Switch 1",
+    "switch2": "Switch 2",
+    "switch3": "Switch 3",
+}
+
+StateListener = Callable[[], None]
+
+
+class HuaweiDevice(HuaweiDeviceStateMixin):
+    """Runtime context and protocol mapping for one 2BN0 device."""
+
+    prod_id = PROD_ID
+    ha_platform = HA_PLATFORM
+    switch_keys = CHANNEL_SERVICE_IDS
+    switch_names = SWITCH_NAMES
+
+    def __init__(
+        self,
+        descriptor: RemoteDeviceDescriptor,
+        mqtt: HuaweiMqttClient,
+    ) -> None:
+        if (descriptor.prod_id or "").strip().upper() != PROD_ID:
+            raise ValueError("2BN0 device requires prodId=2BN0")
+        self._descriptor = descriptor
+        self._mqtt = mqtt
+        self._state: dict[str, dict[str, Any]] = {
+            sid: dict(service.data)
+            for sid, service in descriptor.service_states.items()
+        }
+        self._state_timestamps: dict[str, str] = {
+            sid: service.reported_timestamp
+            for sid, service in descriptor.service_states.items()
+            if service.reported_timestamp
+        }
+        self._listeners: set[StateListener] = set()
+        self._pending_acks: dict[str, asyncio.Future[int]] = {}
+        self._command_lock = asyncio.Lock()
+
+    @property
+    def descriptor(self) -> RemoteDeviceDescriptor:
+        """Return the current discovered device descriptor."""
+
+        return self._descriptor
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Return the stable account/device key."""
+
+        return self._descriptor.key
+
+    @property
+    def home_id(self) -> str:
+        return self._descriptor.home_id
+
+    @property
+    def dev_id(self) -> str:
+        return self._descriptor.dev_id
+
+    @property
+    def name(self) -> str:
+        return self._descriptor.name
+
+    @property
+    def model(self) -> str:
+        return self._descriptor.model or PROFILE_MODEL
+
+    @property
+    def manufacturer(self) -> str:
+        return self._descriptor.manufacturer or MANUFACTURER_NAME
+
+    @property
+    def firmware_version(self) -> str | None:
+        return self._descriptor.firmware_version
+
+    @property
+    def available(self) -> bool:
+        return self._descriptor.online is not False
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._bool_value(SERVICE_SWITCH, "on")
+
+    def feature_is_on(self, characteristic: str) -> bool | None:
+        """Return the state of one independent switch channel."""
+
+        if characteristic not in self.switch_keys:
+            raise ValueError(f"unsupported 2BN0 switch: {characteristic}")
+        return self._bool_value(characteristic, "on")
+
+    def value(self, sid: str, name: str) -> Any:
+        """Return one cached product characteristic."""
+
+        return self._state.get(sid, {}).get(name)
+
+    def add_state_listener(self, listener: StateListener) -> None:
+        self._listeners.add(listener)
+
+    def remove_state_listener(self, listener: StateListener) -> None:
+        self._listeners.discard(listener)
+
+    def update_descriptor(self, descriptor: RemoteDeviceDescriptor) -> None:
+        """Update discovery metadata without replacing newer MQTT state."""
+
+        was_available = self.available
+        self._descriptor = descriptor
+        for sid, service in descriptor.service_states.items():
+            if sid not in self._state:
+                self._state[sid] = dict(service.data)
+            if sid not in self._state_timestamps and service.reported_timestamp:
+                self._state_timestamps[sid] = service.reported_timestamp
+        if was_available != self.available:
+            self._notify_state_changed()
+
+    def close(self) -> None:
+        """Release listeners and wake commands waiting for an ACK."""
+
+        for future in self._pending_acks.values():
+            if not future.done():
+                future.cancel()
+        self._pending_acks.clear()
+        self._listeners.clear()
+
+    def handle_mqtt_message(self, topic: str, payload: bytes) -> bool:
+        """Consume one official SmartHome MQTT envelope."""
+
+        del topic
+        try:
+            message = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return False
+        if not isinstance(message, Mapping):
+            return False
+        body = message.get("body")
+        header = message.get("header")
+        if not isinstance(body, Mapping) or not isinstance(header, Mapping):
+            return False
+
+        notify_type = header.get("notifyType")
+        if notify_type == "commandRsp":
+            return self._handle_command_ack(body, header)
+        if notify_type != "deviceDataChanged" or body.get("devId") != self.dev_id:
+            return False
+
+        services = body.get("services")
+        if not isinstance(services, list):
+            return False
+        changed = False
+        for service in services:
+            if not isinstance(service, Mapping):
+                continue
+            sid = service.get("sid")
+            data = service.get("data")
+            if (
+                not isinstance(sid, str)
+                or sid not in STATE_SERVICES
+                or not isinstance(data, Mapping)
+            ):
+                continue
+            timestamp = service.get("ts")
+            if (
+                isinstance(timestamp, str)
+                and timestamp
+                and self._state_timestamps.get(sid)
+                and timestamp < self._state_timestamps[sid]
+            ):
+                continue
+            before = self._state.get(sid, {})
+            after = {**before, **dict(data)}
+            if after != before:
+                self._state[sid] = after
+                changed = True
+            if isinstance(timestamp, str) and timestamp:
+                self._state_timestamps[sid] = timestamp
+        if changed:
+            self._notify_state_changed()
+        return changed
+
+    async def async_turn_on(self) -> None:
+        """Turn all three switch channels on."""
+
+        await self.async_set_service(SERVICE_SWITCH, {"on": 1})
+
+    async def async_turn_off(self) -> None:
+        """Turn all three switch channels off."""
+
+        await self.async_set_service(SERVICE_SWITCH, {"on": 0})
+
+    async def async_set_feature(self, characteristic: str, enabled: bool) -> None:
+        """Set one independent switch channel."""
+
+        if characteristic not in self.switch_keys:
+            raise ValueError(f"unsupported 2BN0 switch: {characteristic}")
+        await self.async_set_service(
+            characteristic,
+            {"on": 1 if enabled else 0},
+        )
+
+    async def async_set_service(
+        self,
+        sid: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Publish one product command and wait for its service ACK."""
+
+        if sid not in COMMAND_SERVICES:
+            raise ValueError(f"unsupported 2BN0 service: {sid}")
+        target = f"/devices/{self.dev_id}/services/{sid}"
+        async with self._command_lock:
+            request_id = str(uuid.uuid4()).upper()
+            future = asyncio.get_running_loop().create_future()
+            self._pending_acks[target] = future
+            try:
+                await self._mqtt.async_publish_command(
+                    topic=OBSERVED_MQTT_FILTER,
+                    target=target,
+                    body=data,
+                    request_id=request_id,
+                )
+                remote_code = await asyncio.wait_for(
+                    future,
+                    timeout=COMMAND_ACK_TIMEOUT,
+                )
+            finally:
+                self._pending_acks.pop(target, None)
+            if remote_code != 0:
+                raise RuntimeError(
+                    f"2BN0 command rejected: sid={sid} errcode={remote_code}"
+                )
+
+    def _handle_command_ack(
+        self,
+        body: Mapping[str, Any],
+        header: Mapping[str, Any],
+    ) -> bool:
+        target = header.get("from")
+        if not isinstance(target, str):
+            return False
+        future = self._pending_acks.get(target)
+        if future is None or future.done():
+            return False
+        code = body.get("errcode")
+        try:
+            remote_code = int(code)
+        except (TypeError, ValueError):
+            remote_code = -1
+        future.set_result(remote_code)
+        return True
+
+    def _bool_value(self, sid: str, name: str) -> bool | None:
+        value = self.value(sid, name)
+        if value is None:
+            return None
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "on"}:
+                return True
+            if normalized in {"0", "false", "off"}:
+                return False
+        if isinstance(value, (bool, int, float)):
+            return bool(value)
+        return None
+
+    def _notify_state_changed(self) -> None:
+        for listener in tuple(self._listeners):
+            listener()

--- a/custom_components/huawei_smarthome/hwiotdevices/registry.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/registry.py
@@ -13,6 +13,7 @@ _SUPPORTED_PRODUCTS = {
     "108t": import_module(".hvac.108T", package=__package__).HuaweiDevice,
     "100z": import_module(".lights.100z", package=__package__).HuaweiDevice,
     "2mff": import_module(".electrical.2MFF", package=__package__).HuaweiDevice,
+    "2bn0": import_module(".electrical.2BN0", package=__package__).HuaweiDevice,
     "124u": import_module(".electrical.124U", package=__package__).HuaweiDevice,
     "20hz": import_module(".lights.20HZ", package=__package__).HuaweiDevice,
     "2f6r": import_module(".lights.2F6R", package=__package__).HuaweiDevice,

--- a/custom_components/huawei_smarthome/hwiotdevices/state.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/state.py
@@ -1,0 +1,45 @@
+"""Shared state application for supported SmartHome product devices."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+
+from ..domain.models import RemoteServiceState
+
+
+class HuaweiDeviceStateMixin:
+    """Apply a normalized state snapshot to a product device."""
+
+    def apply_state_snapshot(
+        self,
+        services: Mapping[str, RemoteServiceState],
+        *,
+        online: bool | None = None,
+    ) -> bool:
+        """Merge state by service timestamp and notify listeners once."""
+
+        changed = False
+        for sid, service in services.items():
+            timestamp = service.reported_timestamp
+            previous_timestamp = self._state_timestamps.get(sid)
+            if (
+                timestamp
+                and previous_timestamp
+                and timestamp < previous_timestamp
+            ):
+                continue
+            before = self._state.get(sid, {})
+            after = {**before, **dict(service.data)}
+            if after != before:
+                self._state[sid] = after
+                changed = True
+            if timestamp and timestamp != previous_timestamp:
+                self._state_timestamps[sid] = timestamp
+
+        if online is not None and online != self._descriptor.online:
+            self._descriptor = replace(self._descriptor, online=online)
+            changed = True
+        if changed:
+            self._notify_state_changed()
+        return changed


### PR DESCRIPTION
## Summary

- add 2BN0 three-gang wall switch support
- expose the aggregate switch and three independent channel switches
- handle MQTT state updates and command acknowledgements
- add focused protocol tests

## Validation

- 2BN0 tests: 3 passed
- remaining tests excluding the pre-existing test_sync collection error: 68 passed
- compileall passed

## Note

The full suite is currently blocked by the master baseline missing normalize_dynamic_states, which is imported by tests/smarthome/test_sync.py.