### PR TITLE
feat: synchronize device state snapshots

### DIFF
--- a/custom_components/huawei_smarthome/api/client.py
+++ b/custom_components/huawei_smarthome/api/client.py
@@ -10,10 +10,11 @@ from typing import Any
 from urllib.parse import quote
 
 from ..const import (
+    CLOUD_ROUTE_SELECT_PATH,
     DEVICE_DETAIL_PATH,
+    DEVICE_DYNAMIC_DATA_PATH,
     DEVICE_SNAPSHOT_PATH,
     HOME_SNAPSHOT_PATH,
-    CLOUD_ROUTE_SELECT_PATH,
     MESSAGE_CENTER_LOGIN_PATH,
     SMART_HOME_IOS_APP_ID,
     SMART_HOME_USER_AGENT,
@@ -22,6 +23,7 @@ from ..domain.models import (
     AuthSession,
     MessageChannelSession,
     RemoteDeviceDescriptor,
+    RemoteDeviceState,
     RemoteDiscoverySnapshot,
     SmartHomeCloudRoute,
 )
@@ -33,12 +35,16 @@ from .errors import (
     RemoteOperationError,
     TransientNetworkError,
 )
-from .normalizers import normalize_device_detail, normalize_snapshot
+from .normalizers import (
+    normalize_device_detail,
+    normalize_dynamic_states,
+    normalize_snapshot,
+)
 from .transport import AsyncHttpTransport, HttpResponse, UrllibHttpTransport
 
 
 class SmartHomeDiscoveryApi:
-    """HTTP facade for account discovery and device details."""
+    """HTTP facade for account discovery and device state."""
 
     def __init__(
         self,
@@ -60,6 +66,35 @@ class SmartHomeDiscoveryApi:
             self._json(devices),
             self._json(homes),
         )
+
+    async def async_get_dynamic_states(
+        self,
+        session: AuthSession,
+        devices: Sequence[str],
+        *,
+        home_id: str | None = None,
+    ) -> tuple[RemoteDeviceState, ...]:
+        """Fetch the current state for a batch of known devices."""
+
+        device_ids = tuple(dict.fromkeys(device for device in devices if device))
+        if not device_ids:
+            return ()
+        body = json.dumps(
+            device_ids,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        response = await self._request(
+            session,
+            DEVICE_DYNAMIC_DATA_PATH,
+            method="POST",
+            body=body,
+            extra_headers={
+                "Content-Type": "application/json",
+                **({"X-HomeId": home_id} if home_id else {}),
+            },
+        )
+        return normalize_dynamic_states(self._json(response))
 
     async def async_login_message_center(
         self,
@@ -230,7 +265,7 @@ class SmartHomeDiscoveryApi:
         }
         if extra_headers:
             headers.update(extra_headers)
-        if body is not None:
+        if body is not None and "Content-Type" not in headers:
             headers["Content-Type"] = "application/json;charset=UTF-8"
         response: HttpResponse | None = None
         for attempt in range(3):

--- a/custom_components/huawei_smarthome/api/normalizers.py
+++ b/custom_components/huawei_smarthome/api/normalizers.py
@@ -10,6 +10,7 @@ from ..domain.models import (
     DeviceKey,
     Operation,
     RemoteDeviceDescriptor,
+    RemoteDeviceState,
     RemoteDiscoverySnapshot,
     RemoteHome,
     RemoteRoom,
@@ -90,6 +91,50 @@ def normalize_device_detail(payload: Any) -> RemoteDeviceDescriptor:
     return _normalize_device(candidate, datetime.now(timezone.utc))
 
 
+def normalize_dynamic_states(
+    payload: Any,
+    *,
+    received_at: datetime | None = None,
+) -> tuple[RemoteDeviceState, ...]:
+    """Normalize the batch device-state response."""
+
+    received_at = received_at or datetime.now(timezone.utc)
+    if not isinstance(payload, list):
+        raise InvalidProtocolDataError(
+            "dynamic device-state response is not a JSON list"
+        )
+    states: list[RemoteDeviceState] = []
+    seen_ids: set[str] = set()
+    for item in payload:
+        if not isinstance(item, Mapping):
+            continue
+        dev_id = _text(item.get("devId"))
+        if not dev_id:
+            continue
+        if dev_id in seen_ids:
+            raise InvalidProtocolDataError(
+                f"dynamic device-state response contains duplicate device {dev_id!r}"
+            )
+        seen_ids.add(dev_id)
+        services: dict[str, RemoteServiceState] = {}
+        services_raw = item.get("services")
+        if isinstance(services_raw, list):
+            for service in services_raw:
+                normalized = _normalize_service(service, received_at)
+                if normalized is not None:
+                    services[normalized.sid] = normalized
+        online = _normalize_online(item)
+        states.append(
+            RemoteDeviceState(
+                dev_id=dev_id,
+                services=services,
+                online=online,
+                received_at=received_at,
+            )
+        )
+    return tuple(states)
+
+
 def _normalize_homes(payload: Mapping[str, Any]) -> tuple[RemoteHome, ...]:
     house_infos = payload.get("houseInfos")
     if not isinstance(house_infos, list):
@@ -151,10 +196,7 @@ def _normalize_device(
         }
         and _is_json_value(child)
     }
-    online = item.get("online")
-    if not isinstance(online, bool):
-        status = _text(item.get("status"))
-        online = True if status == "online" else False if status == "offline" else None
+    online = _normalize_online(item)
     return RemoteDeviceDescriptor(
         home_id=canonical_home_id(item.get("homeId")),
         dev_id=dev_id,
@@ -173,7 +215,7 @@ def _normalize_device(
         if isinstance(info.get("protType"), (str, int)) else None,
         operations=operations,
         service_states=services,
-        online=online if isinstance(online, bool) else None,
+        online=online,
         tags={str(key): child for key, child in tags.items() if _is_json_value(child)},
         third_party_id=_text(item.get("thirdPartyId")),
         registry_time=_text(item.get("registryTime")),
@@ -220,6 +262,20 @@ def _find_device_object(value: Any) -> Mapping[str, Any] | None:
             found = _find_device_object(child)
             if found is not None:
                 return found
+    return None
+
+
+def _normalize_online(value: Mapping[str, Any]) -> bool | None:
+    """Normalize the explicit or textual device availability value."""
+
+    online = value.get("online")
+    if isinstance(online, bool):
+        return online
+    status = _text(value.get("status"))
+    if status == "online":
+        return True
+    if status == "offline":
+        return False
     return None
 
 

--- a/custom_components/huawei_smarthome/client.py
+++ b/custom_components/huawei_smarthome/client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from datetime import datetime, timezone
 import logging
@@ -18,6 +18,7 @@ from .const import (
     OBSERVED_MQTT_FILTER,
     OBSERVED_MQTT_PORT,
     OBSERVED_MQTT_SUBSCRIPTION_QOS,
+    UNASSIGNED_HOME_ID,
 )
 from .domain.models import (
     AccountState,
@@ -25,7 +26,9 @@ from .domain.models import (
     ConnectionState,
     MqttConnectionSettings,
     RemoteDeviceDescriptor,
+    RemoteDeviceState,
     RemoteDiscoverySnapshot,
+    is_older_remote_timestamp,
 )
 from .errors import ReauthenticationRequired
 from .hwiotdevices.registry import create_hwiot_device
@@ -33,6 +36,7 @@ from .mqtt_client import HuaweiMqttClient
 from .storage.credentials import CredentialBindingError
 from .storage.profile_metadata import ProductMetadataStore
 from .storage.state import AccountStateStore
+from .sync_coordinator import SmartHomeSyncCoordinator
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,13 +100,16 @@ class HuaweiSmartHomeClient:
         self.session: AuthSession | None = None
         self.session_manager: SessionManager | None = None
         self._excluded_device_ids: frozenset[str] = frozenset()
-        self._refresh_lock = asyncio.Lock()
         self._reconnect_task: asyncio.Task[None] | None = None
         self._operation_lock = asyncio.Lock()
         self._hwiot_devices: dict[tuple[str, str], Any] = {}
         self._reconnect_min = reconnect_min
         self._reconnect_max = reconnect_max
         self._started = False
+        self._sync = SmartHomeSyncCoordinator(
+            full_sync=self._async_full_sync,
+            state_sync=self._async_state_sync,
+        )
 
     @property
     def devices(self) -> Mapping[tuple[str, str], RemoteDeviceDescriptor]:
@@ -157,10 +164,10 @@ class HuaweiSmartHomeClient:
                 session = await self.session_manager.async_ensure_oauth_valid()
             session = await self.session_manager.async_ensure_hms_valid()
             self.session = session
-            await self._discover_with_token_recovery(session)
+            await self._sync.async_request_full_sync("startup")
             if self.mqtt_enabled:
                 try:
-                    await self._connect_mqtt(session)
+                    await self._connect_mqtt(self.session or session)
                 except ReauthenticationRequired:
                     raise
                 except Exception as error:
@@ -188,29 +195,14 @@ class HuaweiSmartHomeClient:
     async def async_request_refresh(self) -> AccountState:
         """Refresh the account device snapshot."""
 
-        async with self._refresh_lock:
-            try:
-                session = await self._ensure_hms_session()
-                await self._discover_with_token_recovery(session)
-            except (
-                ReauthenticationRequired,
-                CredentialBindingError,
-            ) as error:
-                self.state.connection = ConnectionState.REAUTH_REQUIRED
-                self.state.last_error = "Huawei SmartHome authentication required"
-                raise ReauthenticationRequired(
-                    "Huawei SmartHome authentication required"
-                ) from error
-            except Exception:
-                self.state.connection = ConnectionState.ERROR
-                self.state.last_error = "Huawei SmartHome discovery failed"
-                raise
+        await self._sync.async_request_full_sync("manual")
         return self.state
 
     async def async_stop(self) -> None:
         """Stop MQTT and the account session."""
 
         self._started = False
+        await self._sync.async_stop()
         task, self._reconnect_task = self._reconnect_task, None
         if task is not None:
             task.cancel()
@@ -240,6 +232,20 @@ class HuaweiSmartHomeClient:
         self.state.devices = devices
         self._sync_hwiot_devices()
         self.state.device_home_index = _device_home_index(snapshot)
+        try:
+            await self._refresh_dynamic_states(
+                session,
+                devices.values(),
+                persist=False,
+            )
+        except AuthExpiredError:
+            raise
+        except Exception as error:
+            _LOGGER.warning(
+                "Huawei SmartHome initial state snapshot failed: %s: %s",
+                type(error).__name__,
+                str(error),
+            )
         self.state.revision += 1
         self.state.last_snapshot_at = snapshot.received_at
         self.state.last_success_at = snapshot.received_at
@@ -251,6 +257,48 @@ class HuaweiSmartHomeClient:
             else ConnectionState.READY
         )
         await self.state_store.async_save(self.state)
+
+    async def _async_full_sync(self, _reason: str) -> None:
+        """Run a complete discovery and state synchronization pass."""
+
+        try:
+            session = await self._ensure_hms_session()
+            await self._discover_with_token_recovery(session)
+        except (
+            ReauthenticationRequired,
+            CredentialBindingError,
+        ) as error:
+            self.state.connection = ConnectionState.REAUTH_REQUIRED
+            self.state.last_error = "Huawei SmartHome authentication required"
+            raise ReauthenticationRequired(
+                "Huawei SmartHome authentication required"
+            ) from error
+        except Exception:
+            self.state.connection = ConnectionState.ERROR
+            self.state.last_error = "Huawei SmartHome discovery failed"
+            raise
+
+    async def _async_state_sync(self, _reason: str) -> None:
+        """Refresh current device state without rebuilding topology."""
+
+        try:
+            session = await self._ensure_hms_session()
+            await self._refresh_dynamic_states_with_token_recovery(session)
+        except (
+            ReauthenticationRequired,
+            CredentialBindingError,
+        ) as error:
+            self.state.connection = ConnectionState.REAUTH_REQUIRED
+            self.state.last_error = "Huawei SmartHome authentication required"
+            raise ReauthenticationRequired(
+                "Huawei SmartHome authentication required"
+            ) from error
+        except Exception as error:
+            _LOGGER.warning(
+                "Huawei SmartHome state snapshot failed: %s: %s",
+                type(error).__name__,
+                str(error),
+            )
 
     def _scope_snapshot(
         self,
@@ -340,6 +388,107 @@ class HuaweiSmartHomeClient:
             ),
         )
 
+    async def _refresh_dynamic_states_with_token_recovery(
+        self,
+        session: AuthSession,
+    ) -> None:
+        """Retry a dynamic state snapshot once after token expiry."""
+
+        try:
+            await self._refresh_dynamic_states(session)
+        except AuthExpiredError:
+            if self.session_manager is None:
+                raise
+            session = await self.session_manager.async_refresh_hms_lite(force=True)
+            self.session = session
+            await self._refresh_dynamic_states(session)
+
+    async def _refresh_dynamic_states(
+        self,
+        session: AuthSession,
+        devices: Iterable[RemoteDeviceDescriptor] | None = None,
+        *,
+        persist: bool = True,
+    ) -> bool:
+        """Fetch and apply the current state for the selected devices."""
+
+        getter = getattr(self.api, "async_get_dynamic_states", None)
+        if not callable(getter):
+            return False
+        source = tuple(
+            devices if devices is not None else self.state.devices.values()
+        )
+        devices_by_home: dict[str | None, list[str]] = {}
+        for device in source:
+            if (
+                (device.node_type or "").strip().upper() == "GROUP"
+                or not device.dev_id
+            ):
+                continue
+            home_id = (
+                None
+                if device.home_id == UNASSIGNED_HOME_ID
+                else device.home_id
+            )
+            devices_by_home.setdefault(home_id, []).append(device.dev_id)
+        if not devices_by_home:
+            return False
+        states: list[RemoteDeviceState] = []
+        for home_id, device_ids_raw in devices_by_home.items():
+            device_ids = tuple(dict.fromkeys(device_ids_raw))
+            if isinstance(self.api, SmartHomeDiscoveryApi):
+                states.extend(
+                    await getter(session, device_ids, home_id=home_id)
+                )
+            else:
+                states.extend(await getter(session, device_ids))
+        state_batch = tuple(states)
+        self._apply_dynamic_states(state_batch)
+        if persist:
+            received_at = max(
+                (
+                    state.received_at
+                    for state in state_batch
+                    if state.received_at is not None
+                ),
+                default=datetime.now(timezone.utc),
+            )
+            self.state.revision += 1
+            self.state.last_snapshot_at = received_at
+            self.state.last_success_at = received_at
+            self.state.stale_since = None
+            self.state.last_error = None
+            await self.state_store.async_save(self.state)
+        return True
+
+    def _apply_dynamic_states(
+        self,
+        states: tuple[RemoteDeviceState, ...],
+    ) -> bool:
+        """Merge dynamic state into descriptors and live product objects."""
+
+        updates = {state.dev_id: state for state in states}
+        changed = False
+        for key, descriptor in tuple(self.state.devices.items()):
+            state = updates.get(descriptor.dev_id)
+            if state is None:
+                continue
+            merged = _merge_dynamic_state(descriptor, state)
+            if merged != descriptor:
+                self.state.devices[key] = merged
+                changed = True
+            runtime = self._hwiot_devices.get(key)
+            if runtime is None:
+                continue
+            apply_snapshot = getattr(runtime, "apply_state_snapshot", None)
+            if callable(apply_snapshot):
+                changed = (
+                    apply_snapshot(state.services, online=state.online)
+                    or changed
+                )
+            runtime.update_descriptor(merged)
+        return changed
+
     async def _discover_with_token_recovery(
         self,
         session: AuthSession,
@@ -405,6 +554,7 @@ class HuaweiSmartHomeClient:
         ):
             try:
                 await self._connect_mqtt(session)
+                self._sync.schedule_state_sync("mqtt_reconnect")
             except ReauthenticationRequired:
                 raise
             except Exception as error:
@@ -460,6 +610,7 @@ class HuaweiSmartHomeClient:
                 session = await self.session_manager.async_ensure_oauth_valid()
                 session = await self.session_manager.async_ensure_hms_valid()
                 await self._connect_mqtt(session)
+                await self._sync.async_request_state_sync("mqtt_reconnect")
                 delay = self._reconnect_min
             except ReauthenticationRequired:
                 self.state.connection = ConnectionState.REAUTH_REQUIRED
@@ -488,6 +639,8 @@ class HuaweiSmartHomeClient:
         """Route one MQTT payload to the matching product devices."""
 
         self.state.last_event_at = datetime.now(timezone.utc)
+        if self._started and self._sync.is_topology_event(payload):
+            self._sync.schedule_full_sync("mqtt_topology_event")
         for device in tuple(self._hwiot_devices.values()):
             device.handle_mqtt_message(topic, payload)
 
@@ -558,4 +711,36 @@ def _merge_device_detail(
         protocol_type=detail.protocol_type or device.protocol_type,
         service_states=detail.service_states or device.service_states,
         online=detail.online if detail.online is not None else device.online,
+    )
+
+
+def _merge_dynamic_state(
+    device: RemoteDeviceDescriptor,
+    state: RemoteDeviceState,
+) -> RemoteDeviceDescriptor:
+    """Merge one dynamic state response into a device descriptor."""
+
+    services = dict(device.service_states)
+    for sid, incoming in state.services.items():
+        previous = services.get(sid)
+        if (
+            previous is not None
+            and is_older_remote_timestamp(
+                incoming.reported_timestamp,
+                previous.reported_timestamp,
+            )
+        ):
+            continue
+        if previous is None:
+            services[sid] = incoming
+            continue
+        services[sid] = replace(
+            incoming,
+            service_type=incoming.service_type or previous.service_type,
+            data={**previous.data, **incoming.data},
+        )
+    return replace(
+        device,
+        service_states=services,
+        online=state.online if state.online is not None else device.online,
     )

--- a/custom_components/huawei_smarthome/const.py
+++ b/custom_components/huawei_smarthome/const.py
@@ -34,6 +34,7 @@ PROFILE_CDN_BASE_URL = "https://smarthome-drcn.dbankcdn.com"
 PROFILE_CDN_PATH = "/device/guide/{prod_id}/{prod_id}.json"
 
 DEVICE_SNAPSHOT_PATH = "/smart-life/v5/devices/info"
+DEVICE_DYNAMIC_DATA_PATH = "/smart-life/v5/devices/dynamic/data"
 HOME_SNAPSHOT_PATH = "/smart-life/v5/homes"
 DEVICE_DETAIL_PATH = "/smart-life/v2/devices/{dev_id}"
 MESSAGE_CENTER_LOGIN_PATH = "/message-center/v1/login"

--- a/custom_components/huawei_smarthome/domain/models.py
+++ b/custom_components/huawei_smarthome/domain/models.py
@@ -151,6 +151,16 @@ class RemoteServiceState:
 
 
 @dataclass(frozen=True, slots=True)
+class RemoteDeviceState:
+    """A device state returned by the dynamic state snapshot endpoint."""
+
+    dev_id: str
+    services: Mapping[str, RemoteServiceState] = field(default_factory=dict)
+    online: bool | None = None
+    received_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class RemoteDeviceDescriptor:
     """Device instance data from the SmartHome discovery API."""
 
@@ -239,6 +249,21 @@ def parse_remote_timestamp(value: Any) -> datetime | None:
         return datetime.strptime(body, pattern).replace(tzinfo=timezone.utc)
     except ValueError:
         return None
+
+
+def is_older_remote_timestamp(
+    incoming: str | None,
+    previous: str | None,
+) -> bool:
+    """Return whether one SmartHome timestamp precedes another."""
+
+    if not incoming or not previous:
+        return False
+    incoming_at = parse_remote_timestamp(incoming)
+    previous_at = parse_remote_timestamp(previous)
+    if incoming_at is not None and previous_at is not None:
+        return incoming_at < previous_at
+    return incoming < previous
 
 
 def datetime_after_now(value: datetime, margin_seconds: int) -> bool:

--- a/custom_components/huawei_smarthome/hwiotdevices/electrical/124U.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/electrical/124U.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "124U"
 HA_PLATFORM = "switch"
@@ -29,11 +30,12 @@ ENERGY_SENSOR_KEYS = frozenset({"current", "consumption"})
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 124U device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     energy_sensor_keys = ENERGY_SENSOR_KEYS
 
     def __init__(
@@ -182,25 +184,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/electrical/2BN0.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/electrical/2BN0.py
@@ -37,6 +37,7 @@ class HuaweiDevice(HuaweiDeviceStateMixin):
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     switch_keys = CHANNEL_SERVICE_IDS
     switch_names = SWITCH_NAMES
 
@@ -178,25 +179,17 @@ class HuaweiDevice(HuaweiDeviceStateMixin):
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/electrical/2MFF.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/electrical/2MFF.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "2MFF"
 HA_PLATFORM = "switch"
@@ -31,11 +32,12 @@ SENSOR_KEYS = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 2MFF device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     sensor_keys = SENSOR_KEYS
 
     def __init__(
@@ -192,25 +194,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/hvac/108T.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/hvac/108T.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "108T"
 HA_PLATFORM = "fan"
@@ -63,11 +64,12 @@ FEATURE_FIELDS = {
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 108T device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     switch_keys = tuple(FEATURE_FIELDS)
     switch_names = FEATURE_FIELDS
     sensor_keys = frozenset({"pm2p5", "filter_remaining"})
@@ -235,25 +237,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/lights/100z.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/lights/100z.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "100z"
 HA_PLATFORM = "light"
@@ -35,11 +36,12 @@ SUPPORTED_SERVICES = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 100z device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = SUPPORTED_SERVICES
 
     def __init__(
         self,
@@ -204,25 +206,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in SUPPORTED_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/lights/20HZ.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/lights/20HZ.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "20HZ"
 HA_PLATFORM = "light"
@@ -43,11 +44,12 @@ COMMAND_SERVICES = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 20HZ device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     supported_color_modes = SUPPORTED_COLOR_MODES
     min_color_temp_kelvin = MIN_COLOR_TEMP_KELVIN
     max_color_temp_kelvin = MAX_COLOR_TEMP_KELVIN
@@ -213,25 +215,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/lights/2F6R.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/lights/2F6R.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "2F6R"
 HA_PLATFORM = "light"
@@ -42,11 +43,12 @@ COMMAND_SERVICES = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 2F6R device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     supported_color_modes = SUPPORTED_COLOR_MODES
 
     def __init__(
@@ -214,25 +216,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/lights/2KJ0.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/lights/2KJ0.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "2KJ0"
 HA_PLATFORM = "light"
@@ -47,11 +48,12 @@ COMMAND_SERVICES = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 2KJ0 device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     supported_color_modes = SUPPORTED_COLOR_MODES
     min_color_temp_kelvin = MIN_COLOR_TEMP_KELVIN
     max_color_temp_kelvin = MAX_COLOR_TEMP_KELVIN
@@ -223,25 +225,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/lights/2OIB.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/lights/2OIB.py
@@ -11,6 +11,7 @@ import uuid
 from ...const import OBSERVED_MQTT_FILTER
 from ...domain.models import RemoteDeviceDescriptor
 from ...mqtt_client import HuaweiMqttClient
+from ..state import HuaweiDeviceStateMixin
 
 PROD_ID = "2OIB"
 HA_PLATFORM = "light"
@@ -47,11 +48,12 @@ COMMAND_SERVICES = frozenset(
 StateListener = Callable[[], None]
 
 
-class HuaweiDevice:
+class HuaweiDevice(HuaweiDeviceStateMixin):
     """Runtime context and protocol mapping for one 2OIB device."""
 
     prod_id = PROD_ID
     ha_platform = HA_PLATFORM
+    state_services = STATE_SERVICES
     supported_color_modes = SUPPORTED_COLOR_MODES
     min_color_temp_kelvin = MIN_COLOR_TEMP_KELVIN
     max_color_temp_kelvin = MAX_COLOR_TEMP_KELVIN
@@ -223,25 +225,17 @@ class HuaweiDevice:
             data = service.get("data")
             if (
                 not isinstance(sid, str)
-                or sid not in STATE_SERVICES
                 or not isinstance(data, Mapping)
             ):
                 continue
-            timestamp = service.get("ts")
-            if (
-                isinstance(timestamp, str)
-                and timestamp
-                and self._state_timestamps.get(sid)
-                and timestamp < self._state_timestamps[sid]
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if isinstance(timestamp, str) and timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    data,
+                    service.get("ts"),
+                )
+                or changed
+            )
         if changed:
             self._notify_state_changed()
         return changed

--- a/custom_components/huawei_smarthome/hwiotdevices/state.py
+++ b/custom_components/huawei_smarthome/hwiotdevices/state.py
@@ -4,12 +4,43 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import replace
+from typing import Any
 
-from ..domain.models import RemoteServiceState
+from ..domain.models import RemoteServiceState, is_older_remote_timestamp
 
 
 class HuaweiDeviceStateMixin:
     """Apply a normalized state snapshot to a product device."""
+
+    state_services: frozenset[str] | None = None
+
+    def _merge_service_state(
+        self,
+        sid: str,
+        data: Mapping[str, Any],
+        timestamp: str | None = None,
+    ) -> bool:
+        """Merge one service update without notifying listeners."""
+
+        allowed_services = self.state_services
+        if allowed_services is not None and sid not in allowed_services:
+            return False
+        timestamp = (
+            timestamp
+            if isinstance(timestamp, str) and timestamp
+            else None
+        )
+        previous_timestamp = self._state_timestamps.get(sid)
+        if is_older_remote_timestamp(timestamp, previous_timestamp):
+            return False
+        before = self._state.get(sid, {})
+        after = {**before, **dict(data)}
+        changed = after != before
+        if changed:
+            self._state[sid] = after
+        if timestamp and timestamp != previous_timestamp:
+            self._state_timestamps[sid] = timestamp
+        return changed
 
     def apply_state_snapshot(
         self,
@@ -21,21 +52,14 @@ class HuaweiDeviceStateMixin:
 
         changed = False
         for sid, service in services.items():
-            timestamp = service.reported_timestamp
-            previous_timestamp = self._state_timestamps.get(sid)
-            if (
-                timestamp
-                and previous_timestamp
-                and timestamp < previous_timestamp
-            ):
-                continue
-            before = self._state.get(sid, {})
-            after = {**before, **dict(service.data)}
-            if after != before:
-                self._state[sid] = after
-                changed = True
-            if timestamp and timestamp != previous_timestamp:
-                self._state_timestamps[sid] = timestamp
+            changed = (
+                self._merge_service_state(
+                    sid,
+                    service.data,
+                    service.reported_timestamp,
+                )
+                or changed
+            )
 
         if online is not None and online != self._descriptor.online:
             self._descriptor = replace(self._descriptor, online=online)

--- a/custom_components/huawei_smarthome/sync_coordinator.py
+++ b/custom_components/huawei_smarthome/sync_coordinator.py
@@ -1,0 +1,275 @@
+"""Account-scoped SmartHome synchronization coordination."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+import json
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SyncKind(StrEnum):
+    """Types of account synchronization supported by SmartHome."""
+
+    FULL = "full"
+    STATE = "state"
+
+
+SyncHandler = Callable[[str], Awaitable[None]]
+
+
+@dataclass(slots=True)
+class _SyncRequest:
+    """One caller waiting for a coalesced synchronization pass."""
+
+    reason: str
+    future: asyncio.Future[None]
+
+
+class SmartHomeSyncCoordinator:
+    """Serialize and coalesce account-level synchronization requests."""
+
+    _TOPOLOGY_NOTIFY_TYPES = frozenset(
+        {
+            "deviceAdd",
+            "deviceAdded",
+            "deviceDelete",
+            "deviceDeleted",
+            "deviceInfoSync",
+            "deviceMove",
+            "deviceMoved",
+            "deviceRemove",
+            "deviceRemoved",
+            "homeUpdated",
+            "roomUpdated",
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        full_sync: SyncHandler,
+        state_sync: SyncHandler,
+    ) -> None:
+        self._full_sync = full_sync
+        self._state_sync = state_sync
+        self._condition = asyncio.Condition()
+        self._pending_full: list[_SyncRequest] = []
+        self._pending_state: list[_SyncRequest] = []
+        self._active_kind: SyncKind | None = None
+        self._active_requests: list[_SyncRequest] = []
+        self._worker: asyncio.Task[None] | None = None
+        self._scheduled_full: asyncio.Task[None] | None = None
+        self._scheduled_state: asyncio.Task[None] | None = None
+        self._stopping = False
+
+    async def async_request_full_sync(self, reason: str) -> None:
+        """Run or join one coalesced full synchronization pass."""
+
+        await self._submit(SyncKind.FULL, reason)
+
+    async def async_request_state_sync(self, reason: str) -> None:
+        """Run or join one coalesced state-only synchronization pass."""
+
+        await self._submit(SyncKind.STATE, reason)
+
+    def schedule_full_sync(
+        self,
+        reason: str,
+        *,
+        delay: float = 0.5,
+    ) -> None:
+        """Schedule a debounced full synchronization for an inbound event."""
+
+        if self._stopping:
+            return
+        task = self._scheduled_full
+        if task is not None and not task.done():
+            return
+        self._scheduled_full = asyncio.create_task(
+            self._run_scheduled_full(reason, delay),
+            name="huawei-smarthome-scheduled-full-sync",
+        )
+
+    def schedule_state_sync(self, reason: str) -> None:
+        """Schedule a non-blocking state synchronization request."""
+
+        if self._stopping:
+            return
+        task = self._scheduled_state
+        if task is not None and not task.done():
+            return
+        self._scheduled_state = asyncio.create_task(
+            self._run_scheduled_state(reason),
+            name="huawei-smarthome-scheduled-state-sync",
+        )
+
+    async def async_stop(self) -> None:
+        """Stop pending synchronization work."""
+
+        self._stopping = True
+        scheduled = self._scheduled_full
+        self._scheduled_full = None
+        if scheduled is not None:
+            scheduled.cancel()
+        scheduled_state = self._scheduled_state
+        self._scheduled_state = None
+        if scheduled_state is not None:
+            scheduled_state.cancel()
+
+        async with self._condition:
+            pending = self._pending_full + self._pending_state
+            self._pending_full.clear()
+            self._pending_state.clear()
+            for request in pending:
+                request.future.cancel()
+            self._condition.notify_all()
+
+        worker = self._worker
+        if worker is not None:
+            worker.cancel()
+        tasks = [
+            task
+            for task in (scheduled, scheduled_state, worker)
+            if task is not None
+        ]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    @classmethod
+    def is_topology_event(cls, payload: bytes) -> bool:
+        """Return whether an MQTT payload announces topology information."""
+
+        try:
+            message = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return False
+        if not isinstance(message, Mapping):
+            return False
+        header = message.get("header")
+        return (
+            isinstance(header, Mapping)
+            and header.get("notifyType") in cls._TOPOLOGY_NOTIFY_TYPES
+        )
+
+    async def _submit(self, kind: SyncKind, reason: str) -> None:
+        if not reason:
+            reason = kind.value
+        future = asyncio.get_running_loop().create_future()
+        request = _SyncRequest(reason, future)
+        async with self._condition:
+            if self._stopping:
+                raise RuntimeError("SmartHome synchronization is stopped")
+            if self._active_kind is SyncKind.FULL:
+                self._active_requests.append(request)
+            elif (
+                self._active_kind is SyncKind.STATE
+                and kind is SyncKind.STATE
+            ):
+                self._active_requests.append(request)
+            elif kind is SyncKind.FULL:
+                self._pending_full.append(request)
+            else:
+                self._pending_state.append(request)
+            if self._worker is None or self._worker.done():
+                self._worker = asyncio.create_task(
+                    self._worker_loop(),
+                    name="huawei-smarthome-sync-worker",
+                )
+            self._condition.notify()
+        await future
+
+    async def _worker_loop(self) -> None:
+        while True:
+            async with self._condition:
+                await self._condition.wait_for(
+                    lambda: (
+                        self._stopping
+                        or self._pending_full
+                        or self._pending_state
+                    )
+                )
+                if self._stopping:
+                    pending = self._pending_full + self._pending_state
+                    self._pending_full.clear()
+                    self._pending_state.clear()
+                    for request in pending:
+                        request.future.cancel()
+                    return
+                if self._pending_full:
+                    kind = SyncKind.FULL
+                    requests = self._pending_full + self._pending_state
+                    self._pending_full.clear()
+                    self._pending_state.clear()
+                else:
+                    kind = SyncKind.STATE
+                    requests = self._pending_state
+                    self._pending_state = []
+                self._active_kind = kind
+                self._active_requests = requests
+
+            error: BaseException | None = None
+            try:
+                handler = (
+                    self._full_sync
+                    if kind is SyncKind.FULL
+                    else self._state_sync
+                )
+                await handler(requests[0].reason)
+            except BaseException as caught:
+                error = caught
+
+            async with self._condition:
+                active = self._active_requests
+                self._active_requests = []
+                self._active_kind = None
+                for request in active:
+                    if request.future.done():
+                        continue
+                    if error is None:
+                        request.future.set_result(None)
+                    else:
+                        request.future.set_exception(error)
+                self._condition.notify_all()
+
+            if isinstance(error, asyncio.CancelledError):
+                raise error
+
+    async def _run_scheduled_full(self, reason: str, delay: float) -> None:
+        try:
+            if delay > 0:
+                await asyncio.sleep(delay)
+            await self.async_request_full_sync(reason)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            _LOGGER.warning(
+                "Huawei SmartHome scheduled sync failed: %s: %s",
+                type(error).__name__,
+                str(error),
+            )
+        finally:
+            current = asyncio.current_task()
+            if self._scheduled_full is current:
+                self._scheduled_full = None
+
+    async def _run_scheduled_state(self, reason: str) -> None:
+        try:
+            await self.async_request_state_sync(reason)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            _LOGGER.warning(
+                "Huawei SmartHome scheduled state sync failed: %s: %s",
+                type(error).__name__,
+                str(error),
+            )
+        finally:
+            current = asyncio.current_task()
+            if self._scheduled_state is current:
+                self._scheduled_state = None


### PR DESCRIPTION
## Summary
- fetch and apply home-scoped dynamic device states
- coordinate full and state-only synchronization requests
- preserve newer MQTT state while applying snapshots

## Tests
- python -m pytest tests/smarthome/test_sync.py