### PR TITLE
fix: log profile persistence failures

### DIFF
--- a/custom_components/huawei_smarthome/storage/profile_metadata.py
+++ b/custom_components/huawei_smarthome/storage/profile_metadata.py
@@ -166,7 +166,16 @@ class HomeAssistantProfileStore:
                     type(error).__name__,
                 )
                 return None
-            await store.async_save({"profile": payload})
+            try:
+                await store.async_save({"profile": payload})
+            except Exception as error:  # noqa: BLE001 - report persistence failure
+                _LOGGER.error(
+                    "Huawei SmartHome Profile persistence failed: "
+                    "prod_id=%s error=%s",
+                    prod_id,
+                    type(error).__name__,
+                )
+                raise
             return profile
 
 


### PR DESCRIPTION
## Summary

- Log Profile cache persistence failures with the affected product ID.
- Preserve the existing exception propagation behavior.

## Testing

- `python -m pytest`