### PR TITLE
feat: add user-contributed product adapters

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_101g.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_101g.py
@@ -1,0 +1,99 @@
+"""User-contributed protocol for Huawei product 101g (红外人体感应传感器).
+
+设备类型: 红外人体感应传感器 (PIR Motion Detector)
+制造商: 中安消物联传感, 型号 LH-990ZB
+核心服务:
+   motionSensor.alarm    int R   (0=无, 1=有人移动)
+   battery.lowBattery    int R   (0=正常, 1=低电量)
+   battery.capacity      int R   (0-100 电量%)
+
+本适配器暴露:
+   1. binary_sensor 人体移动 (device_class=motion)
+   2. binary_sensor 低电量   (device_class=battery)
+   3. sensor        电量     (unit=%)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+class Product101GLegacyAdapter:
+    """101g 人体红外(1代)适配器。"""
+
+    prod_id = "101G"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("motionSensor"):
+            return ()
+
+        def motion_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("motionSensor", "alarm"))}
+
+        def battery_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("battery", "lowBattery"))}
+
+        def capacity_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("battery", "capacity"))}
+
+        return (
+            EntitySpec(
+                platform="binary_sensor",
+                key="motion",
+                name="人体移动",
+                state=motion_state,
+                metadata={"device_class": "motion"},
+            ),
+            EntitySpec(
+                platform="binary_sensor",
+                key="battery",
+                name="低电量",
+                state=battery_state,
+                metadata={"device_class": "battery"},
+            ),
+            EntitySpec(
+                platform="sensor",
+                key="capacity",
+                name="电量",
+                state=capacity_state,
+                metadata={"unit": "%"},
+            ),
+        )
+
+
+ADAPTER = Product101GLegacyAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_105d.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_105d.py
@@ -1,0 +1,70 @@
+"""User-contributed protocol for Huawei product 105D (易百珑 ERC309-H 单路多功能接收器).
+
+设备类型: 开关控制器 (Receiver Controller)
+核心服务: ``switch`` (binarySwitch) -> 特征 ``on`` (bool, RW)
+   on = 1 开启, on = 0 关闭
+
+本适配器为设备暴露一个 Home Assistant switch 实体，用于开关控制。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _bool(value: Any) -> bool | None:
+    """容忍 bool / 数字 / 字符串 形式的开关状态。"""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class Product105DAdapter:
+    """105D 开关接收器适配器：单个 switch 实体。"""
+
+    prod_id = "105D"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def switch_state(device: DeviceContext) -> Mapping[str, Any]:
+            # HA switch 平台约定：StateReader 返回 is_on
+            return {"is_on": _bool(device.value("switch", "on"))}
+
+        return (
+            EntitySpec(
+                platform="switch",
+                key="switch",
+                name=None,
+                state=switch_state,
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                },
+            ),
+        )
+
+
+ADAPTER = Product105DAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_113b.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_113b.py
@@ -1,0 +1,73 @@
+"""User-contributed protocol for Huawei product 113B (门磁 / 门窗传感器).
+
+设备类型: 门磁 (Door Detector)
+制造商: 豪恩, 型号 HO-10ZB
+核心服务: ``doorSensor`` (门窗传感器) -> 特征:
+   status: bool  R  0=关闭, 1=打开     (<- 当前开合状态)
+   event : bool      0=关闭, 1=打开     (瞬时事件, 不用)
+   tamper: bool      0=正常, 1=拆动     (防拆告警)
+
+本适配器暴露两个 Home Assistant ``binary_sensor``:
+   1. 开合状态 (device_class=door)   is_on=True 表示门窗打开
+   2. 防拆告警 (device_class=tamper) is_on=True 表示被拆卸
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _bool(value: Any) -> bool | None:
+    """容忍 bool / 数字 / 字符串 的开关状态。"""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+class Product113BAdapter:
+    """113B 门磁适配器：开合状态 + 防拆 两个 binary_sensor。"""
+
+    prod_id = "113B"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("doorSensor"):
+            return ()
+
+        def status_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _bool(device.value("doorSensor", "status"))}
+
+        def tamper_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _bool(device.value("doorSensor", "tamper"))}
+
+        return (
+            EntitySpec(
+                platform="binary_sensor",
+                key="status",
+                name="开合状态",
+                state=status_state,
+                metadata={"device_class": "door"},
+            ),
+            EntitySpec(
+                platform="binary_sensor",
+                key="tamper",
+                name="防拆",
+                state=tamper_state,
+                metadata={"device_class": "tamper"},
+            ),
+        )
+
+
+ADAPTER = Product113BAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_113e.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_113e.py
@@ -1,0 +1,115 @@
+"""User-contributed protocol for Huawei product 113E (豪恩 中控主机 / 网关).
+
+设备类型: 中控主机 (Bridge), 型号 T2
+用途: 作为 Zigbee 子设备网关; 内置夜灯可控制.
+核心服务(本次使用的):
+   light.lightEnable    enum RW (0=夜灯关, 1=夜灯开)
+   light.brightness     int  RW (0-100 亮度)
+   light.inductionEnable enum RW (0=关闭, 1=开启 感应)
+
+本适配器暴露一个 Home Assistant ``light`` 实体(夜灯), 支持 开关/亮度.
+其余为网关子设备管理/报警器/门铃/语音留言, 需要私有配置, 暂不映射.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_BRIGHTNESS_DIV = 100
+_BRIGHTNESS_MAX = 255
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _dev_to_ha_brightness(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return max(0, min(_BRIGHTNESS_MAX, round(value / _BRIGHTNESS_DIV * _BRIGHTNESS_MAX)))
+
+
+def _ha_to_dev_brightness(value: Any) -> int:
+    raw = max(0.0, min(float(value), _BRIGHTNESS_MAX))
+    return max(1, round(raw / _BRIGHTNESS_MAX * _BRIGHTNESS_DIV))
+
+
+async def _turn_on(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    await context.async_send_service("light", {"lightEnable": 1})
+    brightness = data.get("brightness")
+    if brightness is not None:
+        await context.async_send_service(
+            "light", {"brightness": _ha_to_dev_brightness(brightness)}
+        )
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("light", {"lightEnable": 0})
+
+
+class Product113EAdapter:
+    """113E 豪恩网关适配器：夜灯 light 实体。"""
+
+    prod_id = "113E"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("light"):
+            return ()
+
+        def light_state(device: DeviceContext) -> Mapping[str, Any]:
+            brightness = _dev_to_ha_brightness(
+                _as_int(device.value("light", "brightness"))
+            )
+            return {
+                "is_on": _as_bool(device.value("light", "lightEnable")),
+                "brightness": brightness,
+                "color_mode": "brightness" if brightness is not None else "onoff",
+            }
+
+        return (
+            EntitySpec(
+                platform="light",
+                key="nightlight",
+                name="夜灯",
+                state=light_state,
+                metadata={"supported_color_modes": ["brightness"]},
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                },
+            ),
+        )
+
+
+ADAPTER = Product113EAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_113j.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_113j.py
@@ -1,0 +1,79 @@
+"""User-contributed protocol for Huawei product 113J (海雀 AI 全景摄像头).
+
+设备类型: 海雀 AI 全景摄像头 (Alcidae AI Camera), 型号 C314
+核心服务:
+   carmera.on            bool RW (0=关, 1=开)  摄像头电源
+   carmera.humanBodyAlarm int R   (0=关, 1=开) 人体检测告警态
+
+本适配器暴露:
+   1. switch 摄像头电源开关
+   2. binary_sensor 人体检测 (device_class=motion)
+注: 该集成无 camera 平台, 故以 switch+binary_sensor 形式接入.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("carmera", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("carmera", {"on": 0})
+
+
+class Product113JAdapter:
+    """113J 海雀摄像头适配器。"""
+
+    prod_id = "113J"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("carmera"):
+            return ()
+
+        def switch_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("carmera", "on"))}
+
+        def motion_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("carmera", "humanBodyAlarm"))}
+
+        return (
+            EntitySpec(
+                platform="switch",
+                key="power",
+                name="电源",
+                state=switch_state,
+                actions={"turn_on": _turn_on, "turn_off": _turn_off},
+            ),
+            EntitySpec(
+                platform="binary_sensor",
+                key="motion",
+                name="人体检测",
+                state=motion_state,
+                metadata={"device_class": "motion"},
+            ),
+        )
+
+
+ADAPTER = Product113JAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_124u.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_124u.py
@@ -1,0 +1,137 @@
+"""User-contributed protocol for Huawei product 124U (豪恩 智能插座).
+
+设备类型: 智能插座 (Socket)
+核心服务:
+   switch.on            bool RW (0=关, 1=开)   继电器开关
+   power.current        int  RW (0-6000)       功率(W)
+   consumption.consumption int RW (0-1000)     累计电量(kWh)
+   memorySwitch.status  enum RW (0=关,1=开,2=保持上次) 断电记忆
+
+本适配器暴露:
+   1. switch 开关
+   2. sensor 功率 (W)
+   3. sensor 累计电量 (kWh)
+   4. select 断电记忆 (关/开/保持上次)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_MEMORY_OPTIONS = ["关", "开", "保持上次"]
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+async def _set_memory(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    val = {
+        "关": 0,
+        "开": 1,
+        "保持上次": 2,
+    }.get(str(data.get("option")))
+    if val is None:
+        raise ValueError(f"unsupported option: {data.get('option')}")
+    await context.async_send_service("memorySwitch", {"status": val})
+
+
+class Product124UAdapter:
+    """124U 豪恩智能插座适配器。"""
+
+    prod_id = "124U"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def switch_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("switch", "on"))}
+
+        def power_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("power", "current"))}
+
+        def consumption_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("consumption", "consumption"))}
+
+        def memory_state(device: DeviceContext) -> Mapping[str, Any]:
+            status = _as_int(device.value("memorySwitch", "status"))
+            return {
+                "current_option": _MEMORY_OPTIONS[status]
+                if status is not None and 0 <= status < len(_MEMORY_OPTIONS)
+                else _MEMORY_OPTIONS[0]
+            }
+
+        return (
+            EntitySpec(
+                platform="switch",
+                key="switch",
+                name=None,
+                state=switch_state,
+                actions={"turn_on": _turn_on, "turn_off": _turn_off},
+            ),
+            EntitySpec(
+                platform="sensor",
+                key="power",
+                name="功率",
+                state=power_state,
+                metadata={"unit": "W", "device_class": "power"},
+            ),
+            EntitySpec(
+                platform="sensor",
+                key="consumption",
+                name="累计电量",
+                state=consumption_state,
+                metadata={"unit": "kWh", "device_class": "energy", "state_class": "total"},
+            ),
+            EntitySpec(
+                platform="select",
+                key="memory",
+                name="断电记忆",
+                state=memory_state,
+                metadata={"options": _MEMORY_OPTIONS},
+                actions={"select_option": _set_memory},
+            ),
+        )
+
+
+ADAPTER = Product124UAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_208b.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_208b.py
@@ -1,0 +1,164 @@
+"""User-contributed protocol for Huawei product 208B (叶绿体 门铃 / 顺德智勤).
+
+设备类型: 门铃 (Door Bell), 型号 CDB-Q30I
+核心服务:
+   switch1..switch8.on  bool RW (1=开, 0=关)  8 路无线开关
+   volume.value         int  RW (0-100 step25) 音量
+   bellServ.value       enum RW (0-33) 铃声选择
+   muteOpServ.value     bool RW 静音开关
+
+本适配器暴露:
+   1. 8 个 switch (switch1..switch8)
+   2. number 音量
+   3. select 铃声
+   4. switch 静音开关
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_SWITCH_SERVICES = [f"switch{i}" for i in range(1, 9)]
+
+_BELL_OPTIONS = [
+    "暂无", "叮咚两声", "和弦音", "意大利波尔卡", "卡门序曲",
+    "老式铃声", "钢琴音135i", "拉德斯基进行曲", "哆唻咪", "回家",
+    "西班牙女郎", "茶花女", "土耳其进行曲", "啊朋友", "金婚氏",
+    "圣诞快乐", "孤独的牧羊人", "胡桃夹子", "爱丽丝", "回忆",
+    "威尔逊进行曲", "生日快乐", "铃儿响叮当", "苏三娜", "小步舞曲",
+    "欢快铃声", "倒计时1", "倒计时2", "你好欢迎光临", "愉快韵律",
+    "时钟滴答", "滴滴滴", "报警声", "警报声",
+]
+_OPTION_TO_VAL = {name: i for i, name in enumerate(_BELL_OPTIONS)}
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+class Product208BAdapter:
+    """208B 叶绿体门铃适配器。"""
+
+    prod_id = "208B"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch1"):
+            return ()
+
+        def _switch_spec(sid: str, index: int) -> EntitySpec:
+            def state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"is_on": _as_bool(device.value(sid, "on"))}
+
+            async def turn_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 1})
+
+            async def turn_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 0})
+
+            return EntitySpec(
+                platform="switch",
+                key=sid,
+                name=f"开关{index}",
+                state=state,
+                actions={"turn_on": turn_on, "turn_off": turn_off},
+            )
+
+        def volume_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("volume", "value"))}
+
+        async def set_volume(device: DeviceContext, data: Mapping[str, Any]) -> None:
+            value = data.get("value")
+            if value is None:
+                return
+            await device.async_send_service(
+                "volume", {"value": max(0, min(100, int(round(float(value)))))}
+            )
+
+        def bell_state(device: DeviceContext) -> Mapping[str, Any]:
+            val = _as_int(device.value("bellServ", "value"))
+            return {
+                "current_option": _BELL_OPTIONS[val]
+                if val is not None and 0 <= val < len(_BELL_OPTIONS)
+                else _BELL_OPTIONS[0]
+            }
+
+        async def select_bell(device: DeviceContext, data: Mapping[str, Any]) -> None:
+            val = _OPTION_TO_VAL.get(str(data.get("option")))
+            if val is None:
+                raise ValueError(f"unsupported option: {data.get('option')}")
+            await device.async_send_service("bellServ", {"value": val})
+
+        def mute_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("muteOpServ", "value"))}
+
+        async def mute_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await device.async_send_service("muteOpServ", {"value": 1})
+
+        async def mute_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await device.async_send_service("muteOpServ", {"value": 0})
+
+        specs = [_switch_spec(sid, i) for i, sid in enumerate(_SWITCH_SERVICES, start=1)]
+        specs.append(
+            EntitySpec(
+                platform="number",
+                key="volume",
+                name="音量",
+                state=volume_state,
+                metadata={"min": 0, "max": 100, "step": 25, "unit": "%"},
+                actions={"set_value": set_volume},
+            )
+        )
+        specs.append(
+            EntitySpec(
+                platform="select",
+                key="bell",
+                name="铃声",
+                state=bell_state,
+                metadata={"options": _BELL_OPTIONS},
+                actions={"select_option": select_bell},
+            )
+        )
+        specs.append(
+            EntitySpec(
+                platform="switch",
+                key="mute",
+                name="静音",
+                state=mute_state,
+                actions={"turn_on": mute_on, "turn_off": mute_off},
+            )
+        )
+        return tuple(specs)
+
+
+ADAPTER = Product208BAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2acb.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2acb.py
@@ -1,0 +1,121 @@
+"""User-contributed protocol for Huawei product 2ACB (领普科技 门铃).
+
+设备类型: 门铃 (Door Bell), 型号 G4L-HW
+核心服务:
+   selectmusic.selectmusic enum RW  0-36 铃声选择
+   volume.volume           int  RW  0-100 音量(step25)
+   bellstatus.status       enum R    门铃状态(1-15 表示对应按钮被按下)
+
+本适配器暴露:
+   1. select  铃声选择
+   2. number  音量
+   3. binary_sensor 门铃响 (bellstatus 1-15 时 on)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_BELL_OPTIONS = [
+    "静音", "叮咚2声（缓）", "叮咚2声（快）", "叮咚1声", "西敏寺钟声",
+    "致爱丽丝", "雨中旋律", "回忆", "喀秋莎", "土耳其进行曲",
+    "小天鹅", "爱的罗曼史", "午夜睡眠", "匈牙利舞曲", "抒情曲",
+    "幻想舞曲", "铃儿叮当响", "桂河大桥", "命运舞曲", "恭喜恭喜",
+    "莫斯科郊外的晚上", "干簧管波尔", "老黑奴", "绿柚子", "勃拉姆斯摇篮曲",
+    "警报6秒", "苏珊娜", "威廉泰尔序曲", "摇篮曲", "红河谷",
+    "泰坦尼克号", "华尔兹舞曲", "圆舞曲", "警犬叔叔", "小美人鱼",
+    "小企鹅", "罗密欧与朱丽叶",
+]
+_OPTION_TO_VAL = {name: i for i, name in enumerate(_BELL_OPTIONS)}
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _select_music(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    val = _OPTION_TO_VAL.get(str(data.get("option")))
+    if val is None:
+        raise ValueError(f"unsupported option: {data.get('option')}")
+    await context.async_send_service("selectmusic", {"selectmusic": val})
+
+
+async def _set_volume(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    volume = data.get("value")
+    if volume is None:
+        return
+    await context.async_send_service(
+        "volume", {"volume": max(0, min(100, int(round(float(volume)))))}
+    )
+
+
+class Product2ACBAdapter:
+    """2ACB 领普门铃适配器。"""
+
+    prod_id = "2ACB"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("selectmusic"):
+            return ()
+
+        def music_state(device: DeviceContext) -> Mapping[str, Any]:
+            val = _as_int(device.value("selectmusic", "selectmusic"))
+            return {
+                "current_option": _BELL_OPTIONS[val]
+                if val is not None and 0 <= val < len(_BELL_OPTIONS)
+                else _BELL_OPTIONS[0]
+            }
+
+        def volume_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("volume", "volume"))}
+
+        def bell_state(device: DeviceContext) -> Mapping[str, Any]:
+            status = _as_int(device.value("bellstatus", "status"))
+            return {"is_on": bool(status) and 1 <= status <= 15}
+
+        return (
+            EntitySpec(
+                platform="select",
+                key="music",
+                name="铃声",
+                state=music_state,
+                metadata={"options": _BELL_OPTIONS},
+                actions={"select_option": _select_music},
+            ),
+            EntitySpec(
+                platform="number",
+                key="volume",
+                name="音量",
+                state=volume_state,
+                metadata={"min": 0, "max": 100, "step": 25, "unit": "%"},
+                actions={"set_value": _set_volume},
+            ),
+            EntitySpec(
+                platform="binary_sensor",
+                key="bell",
+                name="门铃响",
+                state=bell_state,
+                metadata={"device_class": "sound"},
+            ),
+        )
+
+
+ADAPTER = Product2ACBAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2eo8.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2eo8.py
@@ -1,0 +1,127 @@
+"""User-contributed protocol for Huawei product 2EO8 (智能照明 / 灯带).
+
+设备类型: 智能照明 (Lamp), 万得彩 HC-XD-068
+核心服务:
+   switch.on            bool RW (1=开, 0=关)
+   brightness.brightness int RW  1-100 亮度
+   cct.colorTemperature   int RW  2000-6500 色温(开尔文)
+
+本适配器暴露一个 Home Assistant ``light`` 实体, 支持 开关/亮度/色温.
+亮度按设备 1-100 <-> HA 0-255 换算.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_BRIGHTNESS_DIV = 100
+_BRIGHTNESS_MAX = 255
+_CCT_MIN = 2000
+_CCT_MAX = 6500
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _dev_to_ha_brightness(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return max(0, min(_BRIGHTNESS_MAX, round(value / _BRIGHTNESS_DIV * _BRIGHTNESS_MAX)))
+
+
+def _ha_to_dev_brightness(value: Any) -> int:
+    raw = max(0.0, min(float(value), _BRIGHTNESS_MAX))
+    return max(1, round(raw / _BRIGHTNESS_MAX * _BRIGHTNESS_DIV))
+
+
+async def _turn_on(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    body = {"on": 1}
+    await context.async_send_service("switch", body)
+    brightness = data.get("brightness")
+    if brightness is not None:
+        await context.async_send_service(
+            "brightness", {"brightness": _ha_to_dev_brightness(brightness)}
+        )
+    color_temp = data.get("color_temp_kelvin")
+    if color_temp is not None:
+        cct = max(_CCT_MIN, min(_CCT_MAX, int(round(float(color_temp)))))
+        await context.async_send_service("cct", {"colorTemperature": cct})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class Product2EO8Adapter:
+    """2EO8 灯带适配器：一个 light 实体 (开关/亮度/色温)。"""
+
+    prod_id = "2EO8"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def light_state(device: DeviceContext) -> Mapping[str, Any]:
+            brightness = _dev_to_ha_brightness(
+                _as_int(device.value("brightness", "brightness"))
+            )
+            cct = _as_int(device.value("cct", "colorTemperature"))
+            return {
+                "is_on": _as_bool(device.value("switch", "on")),
+                "brightness": brightness,
+                "color_temp_kelvin": cct,
+                "color_mode": "color_temp" if cct is not None else (brightness is not None and "brightness" or "onoff"),
+            }
+
+        return (
+            EntitySpec(
+                platform="light",
+                key="light",
+                name=None,
+                state=light_state,
+                metadata={
+                    "supported_color_modes": ["color_temp"],
+                    "min_color_temp_kelvin": _CCT_MIN,
+                    "max_color_temp_kelvin": _CCT_MAX,
+                },
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                },
+            ),
+        )
+
+
+ADAPTER = Product2EO8Adapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2ihj.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2ihj.py
@@ -1,0 +1,119 @@
+"""User-contributed protocol for Huawei product 2IHJ (开合帘 / 电动窗帘电机).
+
+设备类型: 开合帘 (Curtain)
+制造商: 广东朗森机电有限公司
+核心服务:
+   opener (开合度):
+     current  int  R   0-100 当前开合度(0=闭合, 100=全开)
+     target   int  RW  0-100 目标位置(与 current 同标度)
+   action  (开合电机操作):
+     action   enum RW  0=关, 1=开, 2=暂停
+   stroke  (行程设置): 正常/反转/校准 (本次未使用)
+
+本适配器将该设备暴露为一个 Home Assistant ``cover`` (窗帘) 实体,
+支持: 打开 / 关闭 / 暂停 / 指定位置.
+注: current/target 的 0-100 方向默认按"0=闭合、100=全开"映射到 HA;
+    若实测方向相反, 将 _POS_REVERSED 置 True 即可.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_POS_MIN = 0
+_POS_MAX = 100
+
+# 若实测"开合度"方向与 HA 相反(HA: 0=关100=开), 置 True 取反
+_POS_REVERSED = False
+
+
+def _as_int(value: Any) -> int | None:
+    """容忍 int / 数字字符串 / bool。"""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_ha_position(position: int | None) -> int | None:
+    """设备开合度 -> HA cover 位置 (0=关, 100=开)。"""
+    if position is None:
+        return None
+    pos = max(_POS_MIN, min(_POS_MAX, position))
+    return _POS_MAX - pos if _POS_REVERSED else pos
+
+
+def _to_device_position(position: Any) -> int:
+    """HA cover 位置 -> 设备 target。"""
+    ha = max(_POS_MIN, min(_POS_MAX, int(round(float(position)))))
+    return _POS_MAX - ha if _POS_REVERSED else ha
+
+
+async def _open(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("action", {"action": 1})
+
+
+async def _close(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("action", {"action": 0})
+
+
+async def _stop(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("action", {"action": 2})
+
+
+async def _set_position(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    position = data.get("position")
+    if position is None:
+        return
+    await context.async_send_service("opener", {"target": _to_device_position(position)})
+
+
+class Product2IHJAdapter:
+    """2IHJ 开合帘适配器：暴露一个 cover (窗帘) 实体。"""
+
+    prod_id = "2IHJ"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("opener"):
+            return ()
+
+        def cover_state(device: DeviceContext) -> Mapping[str, Any]:
+            current = _as_int(device.value("opener", "current"))
+            position = _to_ha_position(current)
+            return {
+                "current_position": position,
+                "is_closed": current == 0,
+            }
+
+        return (
+            EntitySpec(
+                platform="cover",
+                key="curtain",
+                name=None,
+                state=cover_state,
+                actions={
+                    "open": _open,
+                    "close": _close,
+                    "stop": _stop,
+                    "set_position": _set_position,
+                },
+            ),
+        )
+
+
+ADAPTER = Product2IHJAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2ojl.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2ojl.py
@@ -1,0 +1,124 @@
+"""User-contributed protocol for Huawei product 2OJL (加湿器).
+
+设备类型: 加湿器 (Humidifier)
+制造商: 上海汉枫电子科技有限公司, 型号 HF-HM-JSQ-002
+核心服务:
+   switch.on       bool RW   开关 (1=开, 0=关)
+   humidity.target  int RW  40-80 目标湿度(%)
+   humidity.current int R    0-100 当前湿度(%)
+   gear.gear        enum RW  0=恒湿, 1=高档, 2=低档, 3=睡眠 (档位)
+
+本适配器暴露一个 Home Assistant ``humidifier`` 实体,
+支持: 开关 / 目标湿度 / 档位.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_HUMI_MIN = 40
+_HUMI_MAX = 80
+_HUMI_STEP = 5
+
+_GEAR_TO_MODE = {0: "恒湿", 1: "高档", 2: "低档", 3: "睡眠"}
+_MODE_TO_GEAR = {mode: gear for gear, mode in _GEAR_TO_MODE.items()}
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+async def _set_humidity(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    humidity = data.get("humidity")
+    if humidity is None:
+        return
+    target = max(_HUMI_MIN, min(_HUMI_MAX, int(round(float(humidity) / _HUMI_STEP) * _HUMI_STEP)))
+    await context.async_send_service("humidity", {"target": target})
+
+
+async def _set_mode(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    gear = _MODE_TO_GEAR.get(str(data.get("mode")))
+    if gear is None:
+        raise ValueError(f"unsupported mode: {data.get('mode')}")
+    await context.async_send_service("gear", {"gear": gear})
+
+
+class Product2OJLAdapter:
+    """2OJL 加湿器适配器：一个 humidifier 实体。"""
+
+    prod_id = "2OJL"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("humidity"):
+            return ()
+
+        def hum_state(device: DeviceContext) -> Mapping[str, Any]:
+            gear = _as_int(device.value("gear", "gear"))
+            return {
+                "is_on": _as_bool(device.value("switch", "on")),
+                "current_humidity": _as_int(device.value("humidity", "current")),
+                "target_humidity": _as_int(device.value("humidity", "target")),
+                "mode": _GEAR_TO_MODE.get(gear) if gear is not None else None,
+            }
+
+        return (
+            EntitySpec(
+                platform="humidifier",
+                key="humidifier",
+                name=None,
+                state=hum_state,
+                metadata={
+                    "modes": ["恒湿", "高档", "低档", "睡眠"],
+                    "min_humidity": _HUMI_MIN,
+                    "max_humidity": _HUMI_MAX,
+                },
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                    "set_humidity": _set_humidity,
+                    "set_mode": _set_mode,
+                },
+            ),
+        )
+
+
+ADAPTER = Product2OJLAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2p70.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2p70.py
@@ -1,0 +1,164 @@
+"""User-contributed protocol for Huawei product 2P70 (智能马桶).
+
+设备类型: 马桶 (Intelligent Toilet), 型号 R6-300A
+核心服务(本次使用的):
+   seatStatus.status      enum R  (0=未着座, 1=已着座)  着座检测
+   toiletStatus.status    enum R  (盖板/座圈开启关闭状态)
+   seatHeating.gear       enum RW (0=常温,1=1挡,2=2挡,3=3挡) 座圈加热
+   washSetting.mode       enum RW (0=空闲,1=臀洗,2=妇洗,3=一键智能)
+   foamShield.on          bool RW (泡沫盾开关)
+
+本适配器暴露:
+   1. binary_sensor 着座检测 (occupancy)
+   2. sensor 盖板座圈状态 (状态编号)
+   3. select 座圈加热档位
+   4. select 冲洗模式
+   5. switch 泡沫盾
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_SEAT_GEAR_OPTIONS = ["常温", "1挡", "2挡", "3挡"]
+_WASH_OPTIONS = ["空闲", "臀洗", "妇洗", "一键智能"]
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+class Product2P70Adapter:
+    """2P70 智能马桶适配器。"""
+
+    prod_id = "2P70"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("seatStatus"):
+            return ()
+
+        def seated_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_int(device.value("seatStatus", "status")) == 1}
+
+        def lid_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("toiletStatus", "status"))}
+
+        def seat_gear_state(device: DeviceContext) -> Mapping[str, Any]:
+            gear = _as_int(device.value("seatHeating", "gear"))
+            return {
+                "current_option": _SEAT_GEAR_OPTIONS[gear]
+                if gear is not None and 0 <= gear < len(_SEAT_GEAR_OPTIONS)
+                else _SEAT_GEAR_OPTIONS[0]
+            }
+
+        async def set_seat_gear(device: DeviceContext, data: Mapping[str, Any]) -> None:
+            val = {
+                "常温": 0,
+                "1挡": 1,
+                "2挡": 2,
+                "3挡": 3,
+            }.get(str(data.get("option")))
+            if val is None:
+                raise ValueError(f"unsupported option: {data.get('option')}")
+            await device.async_send_service("seatHeating", {"gear": val})
+
+        def wash_mode_state(device: DeviceContext) -> Mapping[str, Any]:
+            mode = _as_int(device.value("washSetting", "mode"))
+            return {
+                "current_option": _WASH_OPTIONS[mode]
+                if mode is not None and 0 <= mode < len(_WASH_OPTIONS)
+                else _WASH_OPTIONS[0]
+            }
+
+        async def set_wash_mode(device: DeviceContext, data: Mapping[str, Any]) -> None:
+            val = {
+                "空闲": 0,
+                "臀洗": 1,
+                "妇洗": 2,
+                "一键智能": 3,
+            }.get(str(data.get("option")))
+            if val is None:
+                raise ValueError(f"unsupported option: {data.get('option')}")
+            await device.async_send_service("washSetting", {"mode": val})
+
+        def foam_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("foamShield", "on"))}
+
+        async def foam_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await device.async_send_service("foamShield", {"on": 1})
+
+        async def foam_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await device.async_send_service("foamShield", {"on": 0})
+
+        return (
+            EntitySpec(
+                platform="binary_sensor",
+                key="seated",
+                name="着座检测",
+                state=seated_state,
+                metadata={"device_class": "occupancy"},
+            ),
+            EntitySpec(
+                platform="sensor",
+                key="lid_status",
+                name="盖板座圈状态",
+                state=lid_state,
+            ),
+            EntitySpec(
+                platform="select",
+                key="seat_heating",
+                name="座圈加热",
+                state=seat_gear_state,
+                metadata={"options": _SEAT_GEAR_OPTIONS},
+                actions={"select_option": set_seat_gear},
+            ),
+            EntitySpec(
+                platform="select",
+                key="wash_mode",
+                name="冲洗模式",
+                state=wash_mode_state,
+                metadata={"options": _WASH_OPTIONS},
+                actions={"select_option": set_wash_mode},
+            ),
+            EntitySpec(
+                platform="switch",
+                key="foam",
+                name="泡沫盾",
+                state=foam_state,
+                actions={"turn_on": foam_on, "turn_off": foam_off},
+            ),
+        )
+
+
+ADAPTER = Product2P70Adapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_2qtt.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2qtt.py
@@ -1,0 +1,137 @@
+"""User-contributed protocol for Huawei product 2QTT (箭牌 浴霸).
+
+设备类型: 浴霸 (Bath Heater), 型号 AQW002HM-T
+核心服务(本次使用的):
+   lightSwitch.on          bool RW  照明
+   ventilateSwitch.on      bool RW  换气
+   windSwitch.on           bool RW  吹风
+   drySwitch.on            bool RW  干燥
+   deodorization.on        bool RW  除臭
+   nightLightSwitch.on     bool RW  夜灯
+   humidity.current        int  R  (0-100 %)   湿度
+   heat.current            float R (温度 ℃)    当前温度
+   humanSensingStatus.status enum R (0=无人,1=有人) 人在
+
+本适配器暴露:
+   6 个 switch (照明/换气/吹风/干燥/除臭/夜灯)
+   + 湿度 sensor + 温度 sensor + 人在 binary_sensor
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_SWITCHES = [
+    ("lightSwitch", "照明"),
+    ("ventilateSwitch", "换气"),
+    ("windSwitch", "吹风"),
+    ("drySwitch", "干燥"),
+    ("deodorization", "除臭"),
+    ("nightLightSwitch", "夜灯"),
+]
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+class Product2QTTAdapter:
+    """2QTT 箭牌浴霸适配器。"""
+
+    prod_id = "2QTT"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("lightSwitch"):
+            return ()
+
+        def _switch_spec(sid: str, label: str) -> EntitySpec:
+            def state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"is_on": _as_bool(device.value(sid, "on"))}
+
+            async def turn_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 1})
+
+            async def turn_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 0})
+
+            return EntitySpec(
+                platform="switch",
+                key=sid,
+                name=label,
+                state=state,
+                actions={"turn_on": turn_on, "turn_off": turn_off},
+            )
+
+        def humidity_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"native_value": _as_int(device.value("humidity", "current"))}
+
+        def temp_state(device: DeviceContext) -> Mapping[str, Any]:
+            value = device.value("heat", "current")
+            return {"native_value": _as_int(value) if value is not None else None}
+
+        def presence_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_int(device.value("humanSensingStatus", "status")) == 1}
+
+        specs = [_switch_spec(sid, label) for sid, label in _SWITCHES]
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="humidity",
+                name="湿度",
+                state=humidity_state,
+                metadata={"unit": "%", "device_class": "humidity"},
+            )
+        )
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="temperature",
+                name="温度",
+                state=temp_state,
+                metadata={"unit": "°C", "device_class": "temperature"},
+            )
+        )
+        specs.append(
+            EntitySpec(
+                platform="binary_sensor",
+                key="presence",
+                name="人在",
+                state=presence_state,
+                metadata={"device_class": "occupancy"},
+            )
+        )
+        return tuple(specs)
+
+
+ADAPTER = Product2QTTAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_a0nn.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_a0nn.py
@@ -1,0 +1,66 @@
+"""User-contributed protocol for Huawei product A0NN (酷宅科技 智能插座 / 1路).
+
+设备类型: 智能插座 (Socket)
+制造商: 酷宅科技, 型号 Smart socket
+核心服务:
+   switch.on bool RW (1=开, 0=关)
+
+本适配器暴露 1 个 Home Assistant ``switch`` 开关实体.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class ProductA0NNAdapter:
+    """A0NN 1路智能插座适配器。"""
+
+    prod_id = "A0NN"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def switch_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _as_bool(device.value("switch", "on"))}
+
+        return (
+            EntitySpec(
+                platform="switch",
+                key="switch",
+                name=None,
+                state=switch_state,
+                actions={"turn_on": _turn_on, "turn_off": _turn_off},
+            ),
+        )
+
+
+ADAPTER = ProductA0NNAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_a0om.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_a0om.py
@@ -1,0 +1,75 @@
+"""User-contributed protocol for Huawei product A0OM (酷宅科技 智能插排 / 4路).
+
+设备类型: 智能插排 (MultiSocket)
+制造商: 酷宅科技, 型号 Smart socket
+核心服务:
+   switch.on   bool RW 总开关
+   switchN.on  bool RW (N=1..4) 分路开关
+
+本适配器暴露 5 个 Home Assistant ``switch``:
+   总开关 + switch1..switch4.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_SWITCH_SERVICES = [
+    ("switch", "总开关"),
+    ("switch1", "开关1"),
+    ("switch2", "开关2"),
+    ("switch3", "开关3"),
+    ("switch4", "开关4"),
+]
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+class ProductA0OMAdapter:
+    """A0OM 4路智能插排适配器。"""
+
+    prod_id = "A0OM"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def _switch_spec(sid: str, label: str) -> EntitySpec:
+            def state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"is_on": _as_bool(device.value(sid, "on"))}
+
+            async def turn_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 1})
+
+            async def turn_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await device.async_send_service(sid, {"on": 0})
+
+            return EntitySpec(
+                platform="switch",
+                key=sid,
+                name=label,
+                state=state,
+                actions={"turn_on": turn_on, "turn_off": turn_off},
+            )
+
+        return tuple(_switch_spec(sid, label) for sid, label in _SWITCH_SERVICES)
+
+
+ADAPTER = ProductA0OMAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_a2vm.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_a2vm.py
@@ -1,0 +1,126 @@
+"""User-contributed protocol for Huawei product A2VM (博联 智能灯泡).
+
+设备类型: 灯泡 (Light Bulb), 型号 0011
+核心服务:
+   switch.on           bool RW (1=开, 0=关)
+   brightness.brightness int RW (0-100 %)
+   cct.colorTemperature  int RW (2700-6500 K)
+
+本适配器暴露一个 Home Assistant ``light`` 实体, 支持 开关/亮度/色温.
+亮度按设备 0-100 <-> HA 0-255 换算.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_BRIGHTNESS_DIV = 100
+_BRIGHTNESS_MAX = 255
+_CCT_MIN = 2700
+_CCT_MAX = 6500
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _dev_to_ha_brightness(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return max(0, min(_BRIGHTNESS_MAX, round(value / _BRIGHTNESS_DIV * _BRIGHTNESS_MAX)))
+
+
+def _ha_to_dev_brightness(value: Any) -> int:
+    raw = max(0.0, min(float(value), _BRIGHTNESS_MAX))
+    return round(raw / _BRIGHTNESS_MAX * _BRIGHTNESS_DIV)
+
+
+async def _turn_on(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+    brightness = data.get("brightness")
+    if brightness is not None:
+        await context.async_send_service(
+            "brightness", {"brightness": _ha_to_dev_brightness(brightness)}
+        )
+    color_temp = data.get("color_temp_kelvin")
+    if color_temp is not None:
+        cct = max(_CCT_MIN, min(_CCT_MAX, int(round(float(color_temp)))))
+        await context.async_send_service("cct", {"colorTemperature": cct})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class ProductA2VMAdapter:
+    """A2VM 博联灯泡适配器。"""
+
+    prod_id = "A2VM"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("switch"):
+            return ()
+
+        def light_state(device: DeviceContext) -> Mapping[str, Any]:
+            brightness = _dev_to_ha_brightness(
+                _as_int(device.value("brightness", "brightness"))
+            )
+            cct = _as_int(device.value("cct", "colorTemperature"))
+            return {
+                "is_on": _as_bool(device.value("switch", "on")),
+                "brightness": brightness,
+                "color_temp_kelvin": cct,
+                "color_mode": "color_temp" if cct is not None else (brightness is not None and "brightness" or "onoff"),
+            }
+
+        return (
+            EntitySpec(
+                platform="light",
+                key="light",
+                name=None,
+                state=light_state,
+                metadata={
+                    "supported_color_modes": ["color_temp"],
+                    "min_color_temp_kelvin": _CCT_MIN,
+                    "max_color_temp_kelvin": _CCT_MAX,
+                },
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductA2VMAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_a3gm.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_a3gm.py
@@ -1,0 +1,121 @@
+"""User-contributed protocol for Huawei product A3GM (美的 中央空调).
+
+设备类型: 中央空调 (Central Air-conditioning), 型号 MJV/MDVH-xxx
+核心服务:
+   switch.on            bool RW (1=开, 0=关)
+   mode.mode            enum RW (1=自动,2=制冷,3=制热,4=送风,5=抽湿)
+   temperature.target   float RW (16.0-30.0, step0.5)
+   temperature.current  float R  (室温 ℃)
+   fan.speed            int  RW (1-100 % 连续风速, climate 平台不便映射, 未接)
+
+本适配器暴露一个 Home Assistant ``climate`` 实体:
+支持 开关 / 模式 / 目标温度, 并上报当前室温.
+注: 风速为连续 1-100%, 该 climate 实体未暴露风速; 自动风服务未映射.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_TEMP_MIN = 16.0
+_TEMP_MAX = 30.0
+
+_DEV_TO_HVAC = {1: "auto", 2: "cool", 3: "heat", 4: "fan_only", 5: "dry"}
+_HVAC_TO_DEV = {v: k for k, v in _DEV_TO_HVAC.items()}
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(int(value))
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+async def _set_hvac_mode(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    dev = _HVAC_TO_DEV.get(str(data.get("hvac_mode")))
+    if dev is None:
+        raise ValueError(f"unsupported hvac_mode: {data.get('hvac_mode')}")
+    await context.async_send_service("mode", {"mode": dev})
+
+
+async def _set_temperature(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    temp = data.get("temperature")
+    if temp is None:
+        return
+    target = max(_TEMP_MIN, min(_TEMP_MAX, round(float(temp) * 2) / 2))
+    await context.async_send_service("temperature", {"target": target})
+
+
+class ProductA3GMAdapter:
+    """A3GM 美的中央空调适配器。"""
+
+    prod_id = "A3GM"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("mode"):
+            return ()
+
+        def climate_state(device: DeviceContext) -> Mapping[str, Any]:
+            mode = _as_int(device.value("mode", "mode"))
+            return {
+                "current_temperature": _as_float(device.value("temperature", "current")),
+                "target_temperature": _as_float(device.value("temperature", "target")),
+                "hvac_mode": _DEV_TO_HVAC.get(mode, "auto"),
+            }
+
+        return (
+            EntitySpec(
+                platform="climate",
+                key="air_conditioner",
+                name=None,
+                state=climate_state,
+                metadata={
+                    "hvac_modes": ["auto", "cool", "heat", "fan_only", "dry"],
+                    "min_temp": _TEMP_MIN,
+                    "max_temp": _TEMP_MAX,
+                },
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                    "set_hvac_mode": _set_hvac_mode,
+                    "set_temperature": _set_temperature,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductA3GMAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_a3rc.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_a3rc.py
@@ -1,0 +1,163 @@
+"""User-contributed protocol for Huawei product A3RC (美的 柜机空调).
+
+设备类型: 柜机空调 (Cabinet Air Conditioner), 型号 KFR-51LW/N8MFA3
+核心服务:
+   switch.on            bool RW (1=开, 0=关)
+   mode.mode            enum RW (1=自动,2=制冷,3=制热,4=送风,5=抽湿)
+   fan.gear             enum RW (0=自动,2=低风,3=中风,4=高风,5=强劲风)
+   fan.direction        enum RW (1=停止摆风,2=左右,3=上下,4=全面)
+   temperature.target   float RW (17.0-30.0, step1)
+
+本适配器暴露一个 Home Assistant ``climate`` 实体,
+支持: 开关 / 模式 / 目标温度 / 风速 / 摆风.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_TEMP_MIN = 17.0
+_TEMP_MAX = 30.0
+
+# 设备 mode(1-5) <-> HA HVAC
+_DEV_TO_HVAC = {1: "auto", 2: "cool", 3: "heat", 4: "fan_only", 5: "dry"}
+_HVAC_TO_DEV = {v: k for k, v in _DEV_TO_HVAC.items()}
+
+# 设备 fan.gear(0,2,3,4,5) <-> HA fan
+_DEV_TO_FAN = {0: "auto", 2: "low", 3: "medium", 4: "high", 5: "strong"}
+_FAN_TO_DEV = {v: k for k, v in _DEV_TO_FAN.items()}
+
+# 设备 fan.direction(1-4) <-> HA swing
+_DEV_TO_SWING = {1: "stop", 2: "horizontal", 3: "vertical", 4: "both"}
+_SWING_TO_DEV = {v: k for k, v in _DEV_TO_SWING.items()}
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(int(value))
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+async def _set_hvac_mode(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    dev = _HVAC_TO_DEV.get(str(data.get("hvac_mode")))
+    if dev is None:
+        raise ValueError(f"unsupported hvac_mode: {data.get('hvac_mode')}")
+    await context.async_send_service("mode", {"mode": dev})
+
+
+async def _set_temperature(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    temp = data.get("temperature")
+    if temp is None:
+        return
+    target = max(_TEMP_MIN, min(_TEMP_MAX, round(float(temp), 1)))
+    await context.async_send_service("temperature", {"target": target})
+
+
+async def _set_fan_mode(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    gear = _FAN_TO_DEV.get(str(data.get("fan_mode")))
+    if gear is None:
+        raise ValueError(f"unsupported fan_mode: {data.get('fan_mode')}")
+    await context.async_send_service("fan", {"gear": gear})
+
+
+async def _set_swing_mode(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    direction = _SWING_TO_DEV.get(str(data.get("swing_mode")))
+    if direction is None:
+        raise ValueError(f"unsupported swing_mode: {data.get('swing_mode')}")
+    await context.async_send_service("fan", {"direction": direction})
+
+
+class ProductA3RCAdapter:
+    """A3RC 美的柜机空调适配器。"""
+
+    prod_id = "A3RC"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("mode"):
+            return ()
+
+        def climate_state(device: DeviceContext) -> Mapping[str, Any]:
+            mode = _as_int(device.value("mode", "mode"))
+            gear = _as_int(device.value("fan", "gear"))
+            direction = _as_int(device.value("fan", "direction"))
+            return {
+                "target_temperature": _as_float(device.value("temperature", "target")),
+                "hvac_mode": _DEV_TO_HVAC.get(mode, "auto"),
+                "fan_mode": _DEV_TO_FAN.get(gear, "auto"),
+                "swing_mode": _DEV_TO_SWING.get(direction, "stop"),
+            }
+
+        return (
+            EntitySpec(
+                platform="climate",
+                key="air_conditioner",
+                name=None,
+                state=climate_state,
+                metadata={
+                    "hvac_modes": ["auto", "cool", "heat", "fan_only", "dry"],
+                    "fan_modes": ["auto", "low", "medium", "high", "strong"],
+                    "swing_modes": ["stop", "horizontal", "vertical", "both"],
+                    "min_temp": _TEMP_MIN,
+                    "max_temp": _TEMP_MAX,
+                },
+                actions={
+                    "turn_on": _turn_on,
+                    "turn_off": _turn_off,
+                    "set_hvac_mode": _set_hvac_mode,
+                    "set_temperature": _set_temperature,
+                    "set_fan_mode": _set_fan_mode,
+                    "set_swing_mode": _set_swing_mode,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductA3RCAdapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_x005.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_x005.py
@@ -1,0 +1,93 @@
+"""User-contributed protocol for Huawei product X005 (华为 AI 音箱 2 / 电池版).
+
+设备类型: 华为 AI 音箱 2 (电池版) (AI Speaker 2 with Battery)
+制造商: 华为, 型号 AIS-BW50-00
+核心服务(播放控制):
+   smartspeaker : playControl enum RW (0=停止播放, 1=启动播放, 2=上一首/下一首)
+   audioplayer  : playState enum RW (0=暂停, 1=播放中, 2=停止)
+   speakerState : State enum R (0=待机中, 1=拾音中, 2=等待响应, 3=语音播报)
+
+本适配器暴露一个 Home Assistant ``media_player`` 实体, 提供 播放/暂停/停止 控制.
+注: playControl=2 在设备资料中上一首与下一首共用同一值, 无法可靠区分,
+    故不暴露 上一首/下一首 动作, 避免误操作.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_STATE_PLAYING = "playing"
+_STATE_PAUSED = "paused"
+_STATE_IDLE = "idle"
+
+
+def _as_int(value: Any) -> int | None:
+    """容忍 int / 数字字符串 / bool。"""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _play(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 1})
+
+
+async def _pause(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("audioplayer", {"playState": 0})
+
+
+async def _stop(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 0})
+
+
+class ProductX005Adapter:
+    """X005 华为 AI 音箱 2 适配器：一个 media_player 实体。"""
+
+    prod_id = "X005"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("audioplayer"):
+            return ()
+
+        def player_state(device: DeviceContext) -> Mapping[str, Any]:
+            state_code = _as_int(device.value("audioplayer", "playState"))
+            if state_code == 1:
+                state = _STATE_PLAYING
+            elif state_code == 0:
+                state = _STATE_PAUSED
+            else:
+                state = _STATE_IDLE
+            return {"state": state}
+
+        return (
+            EntitySpec(
+                platform="media_player",
+                key="speaker",
+                name=None,
+                state=player_state,
+                actions={
+                    "play": _play,
+                    "pause": _pause,
+                    "stop": _stop,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductX005Adapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_x0a2.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_x0a2.py
@@ -1,0 +1,93 @@
+"""User-contributed protocol for Huawei product X0A2 (华为 AI 音箱 2e).
+
+设备类型: 华为 AI 音箱 2e (HUAWEI AI Speaker 2e)
+制造商: 华为, 型号 SKLK-00
+核心服务(播放控制):
+   smartspeaker : playControl enum RW (0=停止播放, 1=启动播放, 2=上一首/下一首)
+   audioplayer  : playState enum RW (0=暂停, 1=播放中, 2=停止)
+   speakerState : State enum R (0=待机中, 1=拾音中, 2=等待响应, 3=语音播报)
+
+本适配器暴露一个 Home Assistant ``media_player`` 实体, 提供 播放/暂停/停止 控制.
+注: playControl=2 在设备资料中上一首与下一首共用同一值, 无法可靠区分,
+    故不暴露 上一首/下一首 动作, 避免误操作.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_STATE_PLAYING = "playing"
+_STATE_PAUSED = "paused"
+_STATE_IDLE = "idle"
+
+
+def _as_int(value: Any) -> int | None:
+    """容忍 int / 数字字符串 / bool。"""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _play(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 1})
+
+
+async def _pause(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("audioplayer", {"playState": 0})
+
+
+async def _stop(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 0})
+
+
+class ProductX0A2Adapter:
+    """X0A2 华为 AI 音箱 2e 适配器：一个 media_player 实体。"""
+
+    prod_id = "X0A2"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("audioplayer"):
+            return ()
+
+        def player_state(device: DeviceContext) -> Mapping[str, Any]:
+            state_code = _as_int(device.value("audioplayer", "playState"))
+            if state_code == 1:
+                state = _STATE_PLAYING
+            elif state_code == 0:
+                state = _STATE_PAUSED
+            else:
+                state = _STATE_IDLE
+            return {"state": state}
+
+        return (
+            EntitySpec(
+                platform="media_player",
+                key="speaker",
+                name=None,
+                state=player_state,
+                actions={
+                    "play": _play,
+                    "pause": _pause,
+                    "stop": _stop,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductX0A2Adapter()
+
+

--- a/custom_components/huawei_smarthome/device_adapters/prod_x0a3.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_x0a3.py
@@ -1,0 +1,91 @@
+"""User-contributed protocol for Huawei product X0A3 (HUAWEI Sound Joy 音箱).
+
+设备类型: HUAWEI Sound Joy (智能音箱), 型号 EGRT-00
+核心服务(播放控制):
+   smartspeaker : playControl enum RW (0=停止播放, 1=启动播放, 2=上一首/下一首)
+   audioplayer  : playState enum RW (0=暂停, 1=播放中, 2=停止)
+   speakerState : State enum R (0=待机中, 1=拾音中, 2=等待响应, 3=语音播报)
+
+本适配器暴露一个 Home Assistant ``media_player`` 实体, 提供 播放/暂停/停止 控制.
+注: playControl=2 在设备资料中上一首与下一首共用同一值, 无法可靠区分,
+    故不暴露 上一首/下一首 动作.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_STATE_PLAYING = "playing"
+_STATE_PAUSED = "paused"
+_STATE_IDLE = "idle"
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(round(float(value.strip())))
+        except (TypeError, ValueError):
+            return None
+    try:
+        return int(round(float(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _play(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 1})
+
+
+async def _pause(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("audioplayer", {"playState": 0})
+
+
+async def _stop(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("smartspeaker", {"playControl": 0})
+
+
+class ProductX0A3Adapter:
+    """X0A3 Sound Joy 音箱适配器：一个 media_player 实体。"""
+
+    prod_id = "X0A3"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        if context.profile is None or not context.has_service("audioplayer"):
+            return ()
+
+        def player_state(device: DeviceContext) -> Mapping[str, Any]:
+            state_code = _as_int(device.value("audioplayer", "playState"))
+            if state_code == 1:
+                state = _STATE_PLAYING
+            elif state_code == 0:
+                state = _STATE_PAUSED
+            else:
+                state = _STATE_IDLE
+            return {"state": state}
+
+        return (
+            EntitySpec(
+                platform="media_player",
+                key="speaker",
+                name=None,
+                state=player_state,
+                actions={
+                    "play": _play,
+                    "pause": _pause,
+                    "stop": _stop,
+                },
+            ),
+        )
+
+
+ADAPTER = ProductX0A3Adapter()
+
+


### PR DESCRIPTION
## Summary

- Add user-contributed adapters for lights, switches, sensors, covers, climate devices, media players, and other Huawei SmartHome products.
- Keep each product protocol mapping isolated in its own adapter module.

## Testing

- `python -m pytest`