### PR TITLE
feat(device_adapters): add product adapter for 2G4N camera (HQ8C)

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_2g4n.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2g4n.py
@@ -1,0 +1,418 @@
+"""User-contributed protocol for Huawei product 2G4N.
+
+Product: 海雀AI摄像头 云台超清版 2.5K (deviceModel ``HQ8C``, prodId ``2G4N``).
+Profile: https://smarthome-drcn.dbankcdn.com/device/guide/2G4N/2G4N.json
+
+Every entity and command below is derived only from the fields declared by
+that public Profile.  Service IDs, enum values and value ranges are read
+from the Profile at runtime so an unexpected product revision degrades to a
+missing entity instead of a wrong state.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_PROD_ID = "2G4N"
+_CAMERA_SID = "carmera"
+_ALARM_SID = "alarmEvent"
+_VOIP_SID = "voip"
+_NET_INFO_SID = "netInfo"
+_VISIT_POINT_SID = re.compile(r"visitPoint\d+\Z")
+
+_TRIGGER_ON = 1
+_TRIGGER_OFF = 0
+
+
+def _field(
+    profile: Mapping[str, Any],
+    sid: str,
+    name: str,
+) -> Mapping[str, Any] | None:
+    for service in profile.get("services", ()):
+        if not isinstance(service, Mapping) or service.get("serviceId") != sid:
+            continue
+        for field in service.get("characteristics", ()):
+            if isinstance(field, Mapping) and field.get("characteristicName") == name:
+                return field
+    return None
+
+
+def _has_service(profile: Mapping[str, Any], sid: str) -> bool:
+    return any(
+        isinstance(service, Mapping) and service.get("serviceId") == sid
+        for service in profile.get("services", ())
+    )
+
+
+def _profile_on_off_values(
+    field: Mapping[str, Any],
+) -> tuple[Any, Any]:
+    """Resolve the on/off payload values from the Profile enum list."""
+    on_value: Any = None
+    off_value: Any = None
+    for option in field.get("enumList", ()):
+        if not isinstance(option, Mapping) or option.get("enumVal") is None:
+            continue
+        label_en = str(option.get("descEn") or "").casefold()
+        label_ch = str(option.get("descCh") or "")
+        value = option.get("enumVal")
+        if on_value is None and ("on" in label_en or label_ch == "开"):
+            on_value = value
+        elif off_value is None and ("off" in label_en or label_ch == "关"):
+            off_value = value
+    if on_value is None and off_value is None:
+        # Boolean characteristic without an enum list follows the 0/1
+        # wire format shared by this product family.
+        on_value, off_value = _TRIGGER_ON, _TRIGGER_OFF
+    return on_value, off_value
+
+
+def _coerce_payload_value(value: Any, field: Mapping[str, Any]) -> Any:
+    """Encode a command value using the Profile-declared characteristic type."""
+
+    data_type = str(field.get("characteristicType") or "").casefold()
+    if data_type in {"bool", "int", "integer", "enum"}:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return value
+        return int(number) if number.is_integer() else number
+    return value
+
+
+def _bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.strip() in {"1", "true", "on", "开"}:
+            return True
+        if value.strip() in {"0", "false", "off", "关"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _switch_spec(
+    profile: Mapping[str, Any],
+    sid: str,
+    field_name: str,
+    name: str,
+) -> EntitySpec | None:
+    field = _field(profile, sid, field_name)
+    if field is None or "W" not in str(field.get("method") or ""):
+        return None
+    on_value, off_value = _profile_on_off_values(field)
+
+    def state(device: DeviceContext) -> Mapping[str, Any]:
+        return {"is_on": _bool(device.value(sid, field_name))}
+
+    async def turn_on(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+        await device.async_send_service(
+            sid, {field_name: _coerce_payload_value(on_value, field)}
+        )
+
+    async def turn_off(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+        await device.async_send_service(
+            sid, {field_name: _coerce_payload_value(off_value, field)}
+        )
+
+    key = sid if field_name == "on" else f"{sid}_{field_name}"
+    return EntitySpec(
+        platform="switch",
+        key=key,
+        name=name,
+        state=state,
+        actions={"turn_on": turn_on, "turn_off": turn_off},
+    )
+
+
+def _trigger_button_spec(
+    profile: Mapping[str, Any],
+    sid: str,
+    field_name: str,
+    name: str | None,
+) -> EntitySpec | None:
+    """One-shot button backed by a boolean trigger characteristic."""
+
+    field = _field(profile, sid, field_name)
+    if field is None or "W" not in str(field.get("method") or ""):
+        return None
+    on_value, _ = _profile_on_off_values(field)
+
+    async def press(device: DeviceContext, _data: Mapping[str, Any]) -> None:
+        await device.async_send_service(
+            sid, {field_name: _coerce_payload_value(on_value, field)}
+        )
+
+    return EntitySpec(
+        platform="button",
+        key=f"{sid}_{field_name}",
+        name=name,
+        state=lambda device: {},
+        actions={"press": press},
+    )
+
+
+def _visit_point_buttons(
+    profile: Mapping[str, Any],
+) -> list[EntitySpec]:
+    """One button per configured visit point, labelled by its device name."""
+
+    buttons: list[EntitySpec] = []
+    for service in profile.get("services", ()):
+        if not isinstance(service, Mapping):
+            continue
+        sid = service.get("serviceId")
+        if not isinstance(sid, str) or _VISIT_POINT_SID.fullmatch(sid) is None:
+            continue
+        move_field = _field(profile, sid, "move")
+        if move_field is None or "W" not in str(move_field.get("method") or ""):
+            continue
+        on_value, _ = _profile_on_off_values(move_field)
+
+        async def press(
+            device: DeviceContext,
+            _data: Mapping[str, Any],
+            _sid: str = sid,
+            _field: Mapping[str, Any] = move_field,
+            _on: Any = on_value,
+        ) -> None:
+            await device.async_send_service(
+                _sid, {"move": _coerce_payload_value(_on, _field)}
+            )
+
+        buttons.append(
+            EntitySpec(
+                platform="button",
+                key=f"{sid}_move",
+                name=None,  # resolved per device below
+                state=lambda device: {},
+                actions={"press": press},
+            )
+        )
+    return buttons
+
+
+def _binary_sensor_spec(
+    sid: str,
+    field_name: str,
+    name: str,
+) -> EntitySpec:
+    def state(device: DeviceContext) -> Mapping[str, Any]:
+        return {"is_on": _bool(device.value(sid, field_name))}
+
+    return EntitySpec(
+        platform="binary_sensor",
+        key=f"{sid}_{field_name}",
+        name=name,
+        state=state,
+    )
+
+
+def _profile_enum_label(
+    field: Mapping[str, Any] | None,
+    value: Any,
+) -> str | None:
+    """Resolve one reported value to its Profile enum label.
+
+    ``alarmEvent`` fields are declared as ``0/1`` enums whose ``descCh``
+    already carries the user-facing wording ("无人形检测告警" /
+    "有人形检测告警"), so the label is read from the Profile rather than
+    being hardcoded here.
+    """
+
+    if field is None:
+        return None
+    for option in field.get("enumList", ()):
+        if not isinstance(option, Mapping):
+            continue
+        if str(option.get("enumVal")) != str(value):
+            continue
+        label = option.get("descCh") or option.get("descEn")
+        if isinstance(label, str) and label.strip():
+            return label.strip()
+    return None
+
+
+def _alarm_sensor_spec(
+    profile: Mapping[str, Any],
+    field_name: str,
+    name: str,
+) -> EntitySpec:
+    """Expose one ``alarmEvent`` field as its Profile-labelled state.
+
+    A sensor rather than a binary_sensor on purpose: the cloud pushes an
+    alarm once and never reports the cleared value, so a binary_sensor would
+    latch on after the first detection and never change state again, silently
+    breaking automations built on it.  Reporting the Profile label keeps the
+    entity truthful -- it shows the last reported alarm state instead of
+    claiming a detection is happening right now.
+    """
+
+    field = _field(profile, _ALARM_SID, field_name)
+
+    def state(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_ALARM_SID, field_name)
+        if value is None:
+            return {"native_value": None}
+        label = _profile_enum_label(field, value)
+        if label is not None:
+            return {"native_value": label}
+        number = _number(value)
+        return {"native_value": number if number is not None else value}
+
+    return EntitySpec(
+        platform="sensor",
+        key=f"{_ALARM_SID}_{field_name}",
+        name=name,
+        state=state,
+    )
+
+
+def _online_spec() -> EntitySpec:
+    """One connectivity sensor backed by the device's online flag."""
+
+    def state(device: DeviceContext) -> Mapping[str, Any]:
+        return {"is_on": bool(device.available)}
+
+    return EntitySpec(
+        platform="binary_sensor",
+        key="online",
+        name="在线状态",
+        state=state,
+        metadata={"device_class": "connectivity"},
+    )
+
+
+class Product2G4NAdapter:
+    """Keep all 2G4N entity and command choices in this file."""
+
+    prod_id = "2G4N"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None:
+            return ()
+        entities: list[EntitySpec] = []
+
+        entities.append(_online_spec())
+
+        if _has_service(profile, _CAMERA_SID):
+            power = _switch_spec(profile, _CAMERA_SID, "on", "电源")
+            if power is not None:
+                entities.append(power)
+            cruise = _switch_spec(profile, _CAMERA_SID, "cruise", "巡航")
+            if cruise is not None:
+                entities.append(cruise)
+            shoot = _trigger_button_spec(
+                profile, _CAMERA_SID, "shoot", "拍照"
+            )
+            if shoot is not None:
+                entities.append(shoot)
+
+        if _has_service(profile, _ALARM_SID):
+            # Reported as sensors, not binary_sensors: the cloud pushes an
+            # alarm once and never sends the cleared value, so a
+            # binary_sensor would stay on forever after the first detection
+            # and could never trigger again.
+            entities.append(
+                _alarm_sensor_spec(profile, "humanBodyAlarm", "人形检测")
+            )
+            entities.append(
+                _alarm_sensor_spec(profile, "audioAlarm", "异常声音")
+            )
+            entities.append(
+                _alarm_sensor_spec(profile, "videoAlarm", "视频告警")
+            )
+            entities.append(
+                _alarm_sensor_spec(profile, "babyCryAlarm", "婴儿哭声")
+            )
+        if _has_service(profile, _VOIP_SID):
+            entities.append(_binary_sensor_spec(_VOIP_SID, "calling", "呼叫中"))
+            # voip.voipCall (RW) triggers a video call to the phone app; the
+            # camera ACKs the command but never pushes a voip state change,
+            # so the call state cannot be verified over MQTT.  Exposed as
+            # fire-and-forget buttons after real-device confirmation that the
+            # call reaches the bound phone.
+            trigger = _field(profile, _VOIP_SID, "voipCall")
+            if trigger is not None and "W" in str(trigger.get("method") or ""):
+                call_value, hangup_value = _profile_on_off_values(trigger)
+
+                async def press_call(
+                    device: DeviceContext,
+                    _data: Mapping[str, Any],
+                    _value: Any = call_value,
+                    _field: Mapping[str, Any] = trigger,
+                ) -> None:
+                    await device.async_send_service(
+                        _VOIP_SID,
+                        {"voipCall": _coerce_payload_value(_value, _field)},
+                    )
+
+                async def press_hangup(
+                    device: DeviceContext,
+                    _data: Mapping[str, Any],
+                    _value: Any = hangup_value,
+                    _field: Mapping[str, Any] = trigger,
+                ) -> None:
+                    await device.async_send_service(
+                        _VOIP_SID,
+                        {"voipCall": _coerce_payload_value(_value, _field)},
+                    )
+
+                entities.extend(
+                    (
+                        EntitySpec(
+                            platform="button",
+                            key=f"{_VOIP_SID}_call",
+                            name="呼叫",
+                            state=lambda device: {},
+                            actions={"press": press_call},
+                        ),
+                        EntitySpec(
+                            platform="button",
+                            key=f"{_VOIP_SID}_hangup",
+                            name="挂断",
+                            state=lambda device: {},
+                            actions={"press": press_hangup},
+                        ),
+                    )
+                )
+
+        entities.extend(_visit_point_buttons(profile))
+
+        # Resolve per-device visit point labels; points that the device
+        # reports as not configured (enable=0) are skipped entirely, which
+        # matches the vendor app hiding unconfigured presets.
+        resolved: list[EntitySpec] = []
+        for spec in entities:
+            if spec.key.endswith("_move") and spec.name is None:
+                sid = spec.key[: -len("_move")]
+                if _bool(context.value(sid, "enable")) is not True:
+                    continue
+                label = context.value(sid, "name")
+                resolved.append(
+                    EntitySpec(
+                        platform=spec.platform,
+                        key=spec.key,
+                        name=label.strip()
+                        if isinstance(label, str) and label.strip()
+                        else sid,
+                        state=spec.state,
+                        metadata=spec.metadata,
+                        actions=spec.actions,
+                    )
+                )
+            else:
+                resolved.append(spec)
+        return tuple(resolved)
+
+
+ADAPTER = Product2G4NAdapter()


### PR DESCRIPTION
## 概述

按 README「产品适配器贡献」要求，为 **海雀AI摄像头 云台超清版 2.5K**（`prodId=2G4N`，`deviceModel=HQ8C`）贡献单品适配器 `device_adapters/prod_2g4n.py`。

Profile 依据（厂商公开 CDN）：
https://smarthome-drcn.dbankcdn.com/device/guide/2G4N/2G4N.json

实体、枚举取值、命令编码均在运行时从该 Profile 解析（服务存在性、`method` 读写位、`enumList`、`characteristicType`），Profile 未声明的内容不做硬编码；无法验证的命令不提供（见下文）。

## 提供的实体

| 平台 | 实体 | 来源 |
| --- | --- | --- |
| `switch` | 电源 | `carmera.on` |
| `switch` | 巡航 | `carmera.cruise` |
| `button` | 拍照 | `carmera.shoot` |
| `button` | 每个已配置预置位一个按钮（楼梯/大门/电梯/门口） | `visitPointN.move`，名称取设备上报的 `visitPointN.name`，仅生成 `enable=1` 的预置位 |
| `sensor` | 人形检测 / 异常声音 / 视频告警 / 婴儿哭声 | `alarmEvent.*`，取 Profile `enumList.descCh` 文案（如「有人形检测告警」） |
| `binary_sensor` | 呼叫中 | `voip.calling` |
| `binary_sensor` | 在线状态（`connectivity` 设备类） | 设备在线标志 |
| `button` | 呼叫 / 挂断 | `voip.voipCall` |

实体名与 Profile 枚举文案（`enumList.descCh`）对齐。

### 为什么告警是 sensor 而不是 binary_sensor

`alarmEvent.*` 只在检测发生时**推送一次，云端从不下发归零值**。因此二进制传感器会在首次检测后永久停留在 `on`，之后任何一次新的检测都不会再产生状态变化，反而会静默地让建立在其上的自动化失效。

改为 `sensor` 并输出 Profile 自带文案（`无人形检测告警` / `有人形检测告警`），实体只如实表达「最近一次上报的告警状态」，不谎称「此刻正在检测」。这与仓库内 `prod_KW02.py` 对门锁告警的处理方式一致。

## 真机验证

使用一台在线的 2G4N（门口摄像头）完成：

- **电源** off→on→off：云端 ACK + 设备推送（`on:0`→`on:1`）确认 ✅
- **巡航** 开启：ACK + 推送（`cruise:1`）确认 ✅
- **拍照**：ACK 确认 ✅
- **预置点转动**（visitPoint3 大门）：ACK + `visitPoint3` 推送确认 ✅
- **视频呼叫**（`voip.voipCall`）：呼叫真实到达绑定手机（机主确认收到并从 App 挂断）✅；因此以即发即忘的 `呼叫`/`挂断` 按钮提供

## 已观察到的固件行为（代码注释中同步记录）

1. `carmera.cruise` 发送 `0` 时云端 ACK，但设备**从不推送**归零状态，一直保持 `cruise:1`——巡航的关闭目前只能经厂商 App 完成。开关的 off 命令如实发送，状态以设备推送为准。
2. `voip.voipCall` / `voip.calling` 同样**没有状态推送**，因此呼叫功能不建模为开关（避免一个永远显示 off 的假开关），`voip.calling`（只读）保留为「呼叫中」传感器，覆盖设备侧来电方向。
3. `alarmEvent.babyCryAlarm` 在 Profile 中声明但该设备从不上报（厂商云端 AI 功能），实体将保持 `unknown`，供启用了该功能的用户使用。

## 未包含的功能

- **云台 PTZ 转动 / 实时视频流**：走海雀私有媒体通道，不经华为智慧生活 MQTT 服务，无法在本集成内实现
- **update / timer / delay 服务**：设备有推送但不在 Profile 中，动作语义无法验证，暂不暴露
- Profile 未声明而设备实际推送的其他服务（该摄像头暂未观察到）留待验证

## 框架建议（不影响本 PR，供后续讨论）

1. **事件触发钩子**：当前 `HuaweiAdapterEvent.trigger()` 无调用链路，适配器无法上报「设备发生了什么」。告警类信息（人形检测、婴儿哭声、访客呼叫、门锁事件）目前只能以状态型实体表达，连续触发时会丢失中间事件且无法携带 `alarmId` 等属性。若框架允许适配器触发事件，告警类信息可升级为「事件（发生记录）+ 状态实体」的 HA 惯用双层模型，本 PR 的 sensor 也可随之演进。
2. **预置位等带参数动作**：本 PR 以按钮提供（设备不回报「当前朝向」，select 的选中值无法反映真实状态）。若设备侧未来回报当前预置位，select 会是更优载体。

## 隐私声明

以上内容不含账号、令牌、设备序列号、MAC 地址及完整 Profile 快照；引用的 Profile 为厂商公开 CDN 链接。测试过程中对真实设备的控制操作均已获得设备所有者同意。