### PR TITLE
feat: 新增 ZG10/2I7K/2OJQ/124U/2MDV 产品适配器 + light 色温模式校验修复

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_124u.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_124u.py
@@ -1,0 +1,341 @@
+"""User-contributed protocol for Huawei product 124U (正泰智能插座).
+
+Profile: switch.on / power.current (0..6000 W) / consumption.consumption
+(0..1000) / faultDetection.{status bool, code enum 0无故障/1过载警告} /
+netInfo diagnostics / memorySwitch.status enum / timer+timerInfo+delay /
+update.
+
+H5 evidence (h5_001 webpack bundle dedicated to this product, store state
+literally contains proId:"124U"):
+- Main switch: setDeviceInfo({switch: {on: Number(!this.switchOn)}})
+  (home banner toggle; quickmenu switchInfo path is switch/on too).
+- UPDATE_DATA mutation maps reported services: case "switch" -> switchOn,
+  case "power" -> power (raw current, shown as 当前功率 with unit 瓦/W),
+  case "consumption" -> statistics report, case "faultDetection" ->
+  faultCode, case "backlight" -> backlight.
+- Consumption unit: the statistics page queries sid:"consumption",
+  character:"consumption" daily sums and divides by 1e3 to display kWh
+  (i18n kWh:"度", usedToday:"今日用电量") -> the raw characteristic is
+  reported in Wh. color thresholds (red>2000, green<1000 on raw sums)
+  are consistent with Wh per day.
+- faultDetection: i18n fault page "负载过大导致设备断电" /
+  "过载保护已开启" matches Profile enum 1=过载警告.
+- netInfo intensity: Profile int with enumList 20/40/60/80/100 -> 0..4 格.
+
+Not exposed (宁可不出):
+- memorySwitch (断电记忆): Profile declares it RW, but this product's H5
+  bundle never references it (0 occurrences) — no UI, no payload evidence
+  for this device; skipped per the two-source rule.
+- backlight: the H5 renders a backlight toggle ({backlight:{on:N}}), but
+  the Profile has NO backlight service at all — template leftover, the
+  integration's has_service() gate would never pass; not implemented.
+- timer / timerInfo / delay: schedule-record CRUD ({timer:{action:0/1/2,
+  timer:[...]}} / {delay:{action, delay:[{sid:"switch", para:"on", ...}]}})
+  confirmed in app.js, but they are list management, not simple controls;
+  HA automations cover this better.
+- update: zero references in the whole bundle -> no button.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _service(profile: Mapping[str, Any], sid: str) -> Mapping[str, Any] | None:
+    for service in profile.get("services", ()):
+        if isinstance(service, Mapping) and service.get("serviceId") == sid:
+            return service
+    return None
+
+
+def _field(
+    profile: Mapping[str, Any],
+    sid: str,
+    name: str,
+) -> Mapping[str, Any] | None:
+    service = _service(profile, sid)
+    if service is None:
+        return None
+    for field in service.get("characteristics", ()):
+        if isinstance(field, Mapping) and field.get("characteristicName") == name:
+            return field
+    return None
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(number) if number.is_integer() else number
+
+
+def _bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _text(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _enum_labels(field: Mapping[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for option in field.get("enumList", ()) or ():
+        if not isinstance(option, Mapping):
+            continue
+        key = option.get("enumVal")
+        if key is None:
+            continue
+        labels[str(key)] = str(option.get("descCh") or option.get("enumVal"))
+    return labels
+
+
+def _enum_key(value: Any) -> str | None:
+    number = _number(value)
+    return str(int(number)) if number is not None else _text(value)
+
+
+def _enum_text(field: Mapping[str, Any], value: Any) -> str | None:
+    """Map a raw characteristic value to its Profile enum label.
+
+    Unknown values return None (unknown) instead of guessing a label.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    return _enum_labels(field).get(_enum_key(value) or "")
+
+
+async def _turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 1})
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class Product124UAdapter:
+    prod_id = "124U"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None:
+            return ()
+        entities: list[EntitySpec] = []
+        entities.extend(self._switch_entity(context, profile))
+        entities.extend(self._metering_entities(context, profile))
+        entities.extend(self._fault_entities(context, profile))
+        entities.extend(self._net_info_entities(context, profile))
+        return tuple(entities)
+
+    def _switch_entity(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("switch"):
+            return ()
+        if _field(profile, "switch", "on") is None:
+            return ()
+        return (
+            EntitySpec(
+                platform="switch",
+                key="outlet",
+                name=None,
+                state=lambda device: {"is_on": _bool(device.value("switch", "on"))},
+                metadata={},
+                actions={"turn_on": _turn_on, "turn_off": _turn_off},
+            ),
+        )
+
+    def _metering_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        # H5 UPDATE_DATA: power.current -> 当前功率 (i18n 瓦/W, 0..6000).
+        if context.has_service("power") and _field(profile, "power", "current") is not None:
+
+            def power_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value("power", "current"))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="power",
+                    name="当前功率",
+                    state=power_state,
+                    metadata={
+                        "unit": "W",
+                        "device_class": "power",
+                        "state_class": "measurement",
+                    },
+                )
+            )
+        # H5 statistics page divides consumption sums by 1e3 for kWh, so the
+        # raw characteristic is Wh; total_increasing also handles a daily
+        # reset (a decrease is treated as a meter reset by HA).
+        if (
+            context.has_service("consumption")
+            and _field(profile, "consumption", "consumption") is not None
+        ):
+
+            def energy_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {
+                    "native_value": _number(device.value("consumption", "consumption"))
+                }
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="energy",
+                    name="用电量",
+                    state=energy_state,
+                    metadata={
+                        "unit": "Wh",
+                        "device_class": "energy",
+                        "state_class": "total_increasing",
+                    },
+                )
+            )
+        return tuple(entities)
+
+    def _fault_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        if context.has_service("faultDetection"):
+            code_field = _field(profile, "faultDetection", "code")
+            if code_field is not None:
+
+                def fault_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _enum_text(
+                            code_field,
+                            device.value("faultDetection", "code"),
+                        )
+                    }
+
+                entities.append(
+                    EntitySpec(
+                        platform="sensor",
+                        key="fault_status",
+                        name="故障状态",
+                        state=fault_state,
+                        metadata={},
+                    )
+                )
+
+            status_field = _field(profile, "faultDetection", "status")
+            if status_field is not None:
+
+                def problem_state(device: DeviceContext) -> Mapping[str, Any]:
+                    # Profile enum: 1=设备运行异常, 0=运行正常，无错误
+                    status = _number(device.value("faultDetection", "status"))
+                    return {"is_on": None if status is None else status == 1}
+
+                entities.append(
+                    EntitySpec(
+                        platform="binary_sensor",
+                        key="fault_problem",
+                        name="故障告警",
+                        state=problem_state,
+                        metadata={"device_class": "problem"},
+                    )
+                )
+        return tuple(entities)
+
+    def _net_info_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("netInfo"):
+            return ()
+
+        entities: list[EntitySpec] = []
+
+        rssi_field = _field(profile, "netInfo", "RSSI")
+        if rssi_field is not None:
+
+            def rssi_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value("netInfo", "RSSI"))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_rssi",
+                    name="信号强度",
+                    state=rssi_state,
+                    metadata={"state_class": "measurement"},
+                )
+            )
+
+        intensity_field = _field(profile, "netInfo", "intensity")
+        if intensity_field is not None:
+
+            def intensity_state(device: DeviceContext) -> Mapping[str, Any]:
+                # Profile enum: 20/40/60/80/100 -> 0..4 格信号
+                return {
+                    "native_value": _enum_text(
+                        intensity_field,
+                        device.value("netInfo", "intensity"),
+                    )
+                }
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_level",
+                    name="信号等级",
+                    state=intensity_state,
+                    metadata={},
+                )
+            )
+
+        for char_name, key, label in (
+            ("SSID", "wifi_ssid", "Wi-Fi 名称"),
+            ("IP", "wifi_ip", "IP 地址"),
+            ("BSSID", "wifi_bssid", "BSSID"),
+        ):
+            if _field(profile, "netInfo", char_name) is None:
+                continue
+
+            def text_state(device: DeviceContext, name: str = char_name) -> Mapping[str, Any]:
+                return {"native_value": _text(device.value("netInfo", name))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key=key,
+                    name=label,
+                    state=text_state,
+                    metadata={},
+                )
+            )
+
+        return tuple(entities)
+
+
+ADAPTER = Product124UAdapter()

--- a/custom_components/huawei_smarthome/device_adapters/prod_2i7k.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2i7k.py
@@ -1,0 +1,383 @@
+"""User-contributed protocol for Huawei product 2I7K (OPPLE lighting drive).
+
+Profile: switch.on / brightness.brightness (1..100%) / cct.colorTemperature
+(2700..5700) / commonFaultDetection.{code,status} / netInfo diagnostics.
+
+H5 evidence (h5_001/js/index.js, template-style unminified bundle):
+- LampBanner1.onCardClick  -> setDeviceInfo({switch: {on: Number(e)}})
+- LampBrightness1.ontouchend -> setDeviceInfo({brightness: {brightness: Number(e)}})
+- LampCCT1.ontouchend -> setDeviceInfo({cct: {colorTemperature: Number(e)}})
+- colourMode only ever appears in updateUI() and has no Profile service -> ignored.
+- toggleSwitch ("开关翻转") is rendered as a GeneralCard with disabled:true and
+  has no event handler anywhere in the bundle (no setDeviceInfo reference) ->
+  no entity is exposed for it (宁可不出).
+- The update service has no UI in this bundle (sdk.js setDeviceInfo call sites
+  only cover timer / progressTurnOff template leftovers that are absent from
+  this Profile) -> no button is exposed for it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _service(profile: Mapping[str, Any], sid: str) -> Mapping[str, Any] | None:
+    for service in profile.get("services", ()):
+        if isinstance(service, Mapping) and service.get("serviceId") == sid:
+            return service
+    return None
+
+
+def _field(
+    profile: Mapping[str, Any],
+    sid: str,
+    name: str,
+) -> Mapping[str, Any] | None:
+    service = _service(profile, sid)
+    if service is None:
+        return None
+    for field in service.get("characteristics", ()):
+        if isinstance(field, Mapping) and field.get("characteristicName") == name:
+            return field
+    return None
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(number) if number.is_integer() else number
+
+
+def _bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _text(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _profile_range(field: Mapping[str, Any]) -> tuple[float, float] | None:
+    minimum = _number(field.get("min"))
+    maximum = _number(field.get("max"))
+    if minimum is None or maximum is None or maximum <= minimum:
+        return None
+    return float(minimum), float(maximum)
+
+
+def _clamp(value: Any, field: Mapping[str, Any]) -> int | float | None:
+    number = _number(value)
+    value_range = _profile_range(field)
+    if number is None or value_range is None:
+        return number
+    minimum, maximum = value_range
+    number = min(max(float(number), minimum), maximum)
+    return int(number) if number.is_integer() else number
+
+
+def _device_brightness_to_ha(
+    value: Any,
+    field: Mapping[str, Any],
+) -> int | None:
+    """Convert the product's 1..100% brightness to HA's 1..255 scale.
+
+    HA treats brightness 0 as "off", so the device's minimum level maps to
+    HA brightness 1 instead of 0 (otherwise the lowest step would collapse
+    into "off").
+    """
+    number = _number(value)
+    value_range = _profile_range(field)
+    if number is None or value_range is None:
+        return None
+    minimum, maximum = value_range
+    number = min(max(float(number), minimum), maximum)
+    return round(1 + (number - minimum) * 254 / (maximum - minimum))
+
+
+def _ha_brightness_to_device(
+    value: Any,
+    field: Mapping[str, Any],
+) -> int | float:
+    """Convert HA's 1..255 brightness back to the product Profile range."""
+
+    number = _number(value)
+    value_range = _profile_range(field)
+    if number is None or value_range is None:
+        raise ValueError("2I7K brightness range is missing from the Profile")
+    minimum, maximum = value_range
+    number = min(max(float(number), 1.0), 255.0)
+    device_value = minimum + (number - 1.0) * (maximum - minimum) / 254.0
+    if (field.get("characteristicType") or "").casefold() in {"int", "integer"}:
+        return int(round(device_value))
+    return device_value
+
+
+def _enum_labels(field: Mapping[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for option in field.get("enumList", ()) or ():
+        if not isinstance(option, Mapping):
+            continue
+        key = option.get("enumVal")
+        if key is None:
+            continue
+        labels[str(key)] = str(option.get("descCh") or option.get("enumVal"))
+    return labels
+
+
+def _enum_text(field: Mapping[str, Any], value: Any) -> str | None:
+    """Map a raw characteristic value to its Profile enum label.
+
+    Unknown values return None (unknown) instead of guessing a label.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    number = _number(value)
+    key = str(int(number)) if number is not None else str(value)
+    return _enum_labels(field).get(key)
+
+
+async def _turn_on(context: DeviceContext, data: Mapping[str, Any]) -> None:
+    profile = context.profile or {}
+    await context.async_send_service("switch", {"on": 1})
+    if data.get("brightness") is not None:
+        brightness_field = _field(profile, "brightness", "brightness")
+        if brightness_field is None:
+            raise ValueError("2I7K brightness field is missing from the Profile")
+        await context.async_send_service(
+            "brightness",
+            {
+                "brightness": _ha_brightness_to_device(
+                    data["brightness"],
+                    brightness_field,
+                )
+            },
+        )
+    if data.get("color_temp_kelvin") is not None:
+        cct_field = _field(profile, "cct", "colorTemperature")
+        if cct_field is None:
+            raise ValueError("2I7K cct field is missing from the Profile")
+        temperature = _clamp(data["color_temp_kelvin"], cct_field)
+        if temperature is not None:
+            await context.async_send_service(
+                "cct",
+                {"colorTemperature": temperature},
+            )
+
+
+async def _turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await context.async_send_service("switch", {"on": 0})
+
+
+class Product2I7KAdapter:
+    prod_id = "2I7K"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None or not context.has_service("switch"):
+            return ()
+        if _field(profile, "switch", "on") is None:
+            return ()
+
+        entities: list[EntitySpec] = []
+        entities.extend(self._light_entities(context, profile))
+        entities.extend(self._fault_entities(context, profile))
+        entities.extend(self._net_info_entities(context, profile))
+        return tuple(entities)
+
+    def _light_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        brightness_field = _field(profile, "brightness", "brightness")
+        cct_field = _field(profile, "cct", "colorTemperature")
+
+        supported_modes: set[str] = set()
+        if cct_field is not None and _profile_range(cct_field) is not None:
+            supported_modes.add("color_temp")
+        if brightness_field is not None and _profile_range(brightness_field) is not None:
+            supported_modes.add("brightness")
+        if not supported_modes:
+            supported_modes.add("onoff")
+
+        def light_state(device: DeviceContext) -> Mapping[str, Any]:
+            state: dict[str, Any] = {
+                "is_on": _bool(device.value("switch", "on")),
+                "brightness": None,
+                "color_temp_kelvin": None,
+                "color_mode": (
+                    "color_temp"
+                    if "color_temp" in supported_modes
+                    else ("brightness" if "brightness" in supported_modes else "onoff")
+                ),
+            }
+            if "brightness" in supported_modes:
+                state["brightness"] = _device_brightness_to_ha(
+                    device.value("brightness", "brightness"),
+                    brightness_field or {},
+                )
+            if "color_temp" in supported_modes:
+                state["color_temp_kelvin"] = _number(
+                    device.value("cct", "colorTemperature")
+                )
+            return state
+
+        metadata: dict[str, Any] = {"supported_color_modes": supported_modes}
+        if "color_temp" in supported_modes:
+            metadata["min_color_temp_kelvin"] = (cct_field or {}).get("min")
+            metadata["max_color_temp_kelvin"] = (cct_field or {}).get("max")
+
+        return (
+            EntitySpec(
+                platform="light",
+                key="light",
+                name=None,
+                state=light_state,
+                metadata=metadata,
+                actions={"turn_on": _turn_on, "turn_off": _turn_off},
+            ),
+        )
+
+    def _fault_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        if context.has_service("commonFaultDetection"):
+            code_field = _field(profile, "commonFaultDetection", "code")
+            if code_field is not None:
+
+                def fault_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _enum_text(
+                            code_field,
+                            device.value("commonFaultDetection", "code"),
+                        )
+                    }
+
+                entities.append(
+                    EntitySpec(
+                        platform="sensor",
+                        key="fault_status",
+                        name="故障状态",
+                        state=fault_state,
+                        metadata={},
+                    )
+                )
+
+            status_field = _field(profile, "commonFaultDetection", "status")
+            if status_field is not None:
+
+                def problem_state(device: DeviceContext) -> Mapping[str, Any]:
+                    # Profile enum: 1=设备运行异常, 0=运行正常
+                    status = _number(device.value("commonFaultDetection", "status"))
+                    return {"is_on": None if status is None else status == 1}
+
+                entities.append(
+                    EntitySpec(
+                        platform="binary_sensor",
+                        key="fault_problem",
+                        name="故障告警",
+                        state=problem_state,
+                        metadata={"device_class": "problem"},
+                    )
+                )
+        return tuple(entities)
+
+    def _net_info_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("netInfo"):
+            return ()
+
+        entities: list[EntitySpec] = []
+
+        rssi_field = _field(profile, "netInfo", "RSSI")
+        if rssi_field is not None:
+
+            def rssi_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value("netInfo", "RSSI"))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_rssi",
+                    name="信号强度",
+                    state=rssi_state,
+                    metadata={
+                        "unit": rssi_field.get("unit"),
+                        "state_class": "measurement",
+                    },
+                )
+            )
+
+        intensity_field = _field(profile, "netInfo", "intensity")
+        if intensity_field is not None:
+
+            def intensity_state(device: DeviceContext) -> Mapping[str, Any]:
+                # Profile enum: 20/40/60/80/100 -> 0..4 格信号
+                return {
+                    "native_value": _enum_text(
+                        intensity_field,
+                        device.value("netInfo", "intensity"),
+                    )
+                }
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_level",
+                    name="信号等级",
+                    state=intensity_state,
+                    metadata={},
+                )
+            )
+
+        for char_name, key, label in (
+            ("SSID", "wifi_ssid", "Wi-Fi 名称"),
+            ("IP", "wifi_ip", "IP 地址"),
+            ("BSSID", "wifi_bssid", "BSSID"),
+        ):
+            if _field(profile, "netInfo", char_name) is None:
+                continue
+
+            def text_state(device: DeviceContext, name: str = char_name) -> Mapping[str, Any]:
+                return {"native_value": _text(device.value("netInfo", name))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key=key,
+                    name=label,
+                    state=text_state,
+                    metadata={},
+                )
+            )
+
+        return tuple(entities)
+
+
+ADAPTER = Product2I7KAdapter()

--- a/custom_components/huawei_smarthome/device_adapters/prod_2mdv.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2mdv.py
@@ -1,0 +1,526 @@
+"""User-contributed protocol for Huawei product 2MDV (杜亚 PLC 版开合帘电机 尊享款 H2).
+
+Profile: opener.{current R, target RW} 0..100% / action.action enum
+(0关/1开/2暂停/3开停/4关停/5开关停) / speed.motorSpeed 1..100% /
+switchSpeed.action enum 0一档/1二档/2三档 / changeDirection.action enum /
+placeMemory.{action W, code R} / lightSwitch.action enum 0关1开 /
+selfCheck.on bool / faultDetection.{status, code} / netInfo.
+
+H5 evidence (h5_001 webpack bundle, DOOYA curtain motor):
+- open/close/stop buttons: setDevInfo({action:{action:1|0|2}}) (clickOpen /
+  clickClose / clickStop, both home and big-curtain pages).
+- position slider touchend: setDevInfo({opener:{target: 100-this.current}})
+  — the 100-x is the H5's mirrored canvas transform; the device value is
+  plain 0..100 where quickmenu defines opener/target=100 全开, 0 全关.
+- speed semimodal submit: setDevInfo({speed:{motorSpeed: N}}).
+- speed gears radio: setDevInfo({switchSpeed:{action: 0|1|2}}).
+- indicator light: setDevInfo({lightSwitch:{action: 0|1}}) toggled from the
+  current lwmpSwitch state.
+- self check: clickSelf -> setDevInfo({selfCheck:{on: 1}}); the H5 then
+  watches selfCheck.on fall back to 0 and toasts "检测完成" (a pulse, so a
+  button rather than a switch).
+- direction page confirm: setDevInfo({changeDirection:{action: 1}});
+  the built-in validation schema declares changeDirection.action as
+  mean:"启用" range:[1] — only value 1 is ever written. i18n: "是否更换设备
+  转向？...更换设备转向后，行程需要重新设置".
+- built-in validation schema (part of this bundle) declares every service
+  above with the same labels as the Profile, e.g. opener.target
+  mean:["关了"] range 0..100, action.action mean ["关","开","暂停",...].
+- commitHilink validates every reported field against that schema before
+  storing, so state values are the raw characteristic values.
+
+Not exposed (宁可不出):
+- placeMemory.action IS wired into buttons below — but note the H5 never
+  dispatches it (the app only *displays* placeMemory.code and warns that
+  travel limits must be re-set after a direction change); the write
+  semantics come from the bundle's validation schema (mean ["设置限位",
+  "清除全部限位"], range [0,1]) plus the Profile. 清除全部限位 wipes the
+  motor's travel limits — it is exposed as an explicit button because it
+  is a documented device function, but it should be pressed deliberately.
+- action.action values 3/4/5 (开停/关停/开关停): only 0/1/2 have send
+  evidence; the others are treated as reported states, never sent.
+- update: the schema declares it, but no UI dispatch site exists in the
+  bundle -> no button.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _service(profile: Mapping[str, Any], sid: str) -> Mapping[str, Any] | None:
+    for service in profile.get("services", ()):
+        if isinstance(service, Mapping) and service.get("serviceId") == sid:
+            return service
+    return None
+
+
+def _field(
+    profile: Mapping[str, Any],
+    sid: str,
+    name: str,
+) -> Mapping[str, Any] | None:
+    service = _service(profile, sid)
+    if service is None:
+        return None
+    for field in service.get("characteristics", ()):
+        if isinstance(field, Mapping) and field.get("characteristicName") == name:
+            return field
+    return None
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(number) if number.is_integer() else number
+
+
+def _text(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _profile_range(field: Mapping[str, Any]) -> tuple[float, float] | None:
+    minimum = _number(field.get("min"))
+    maximum = _number(field.get("max"))
+    if minimum is None or maximum is None or maximum <= minimum:
+        return None
+    return float(minimum), float(maximum)
+
+
+def _clamp_to_profile(value: Any, field: Mapping[str, Any]) -> int | float | None:
+    number = _number(value)
+    value_range = _profile_range(field)
+    if number is None or value_range is None:
+        return number
+    minimum, maximum = value_range
+    number = min(max(float(number), minimum), maximum)
+    return int(number) if number.is_integer() else number
+
+
+def _enum_labels(field: Mapping[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for option in field.get("enumList", ()) or ():
+        if not isinstance(option, Mapping):
+            continue
+        key = option.get("enumVal")
+        if key is None:
+            continue
+        labels[str(key)] = str(option.get("descCh") or option.get("enumVal"))
+    return labels
+
+
+def _enum_key(value: Any) -> str | None:
+    number = _number(value)
+    return str(int(number)) if number is not None else _text(value)
+
+
+def _enum_text(field: Mapping[str, Any], value: Any) -> str | None:
+    """Map a raw characteristic value to its Profile enum label.
+
+    Unknown values return None (unknown) instead of guessing a label.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    return _enum_labels(field).get(_enum_key(value) or "")
+
+
+def _enum_payload(value: str, field: Mapping[str, Any]) -> Any:
+    """Convert a selected label back to the wire value (ints for numeric enums)."""
+    for key, label in _enum_labels(field).items():
+        if label == value:
+            try:
+                return int(float(key))
+            except (TypeError, ValueError):
+                return key
+    return None
+
+
+async def _send_action_value(context: DeviceContext, value: int) -> None:
+    await context.async_send_service("action", {"action": value})
+
+
+async def _cover_open(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await _send_action_value(context, 1)
+
+
+async def _cover_close(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await _send_action_value(context, 0)
+
+
+async def _cover_stop(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+    await _send_action_value(context, 2)
+
+
+class Product2MDVAdapter:
+    prod_id = "2MDV"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None:
+            return ()
+        entities: list[EntitySpec] = []
+        entities.extend(self._cover_entity(context, profile))
+        entities.extend(self._speed_entities(context, profile))
+        entities.extend(self._light_entity(context, profile))
+        entities.extend(self._button_entities(context, profile))
+        entities.extend(self._fault_entities(context, profile))
+        entities.extend(self._net_info_entities(context, profile))
+        return tuple(entities)
+
+    def _cover_entity(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("opener") or not context.has_service("action"):
+            return ()
+        target_field = _field(profile, "opener", "target")
+        if target_field is None:
+            return ()
+
+        def cover_state(device: DeviceContext) -> Mapping[str, Any]:
+            position = _number(device.value("opener", "current"))
+            return {
+                "current_position": position,
+                # quickmenu: opener/target=0 -> 全关
+                "is_closed": None if position is None else position == 0,
+            }
+
+        async def set_position(context: DeviceContext, data: Mapping[str, Any]) -> None:
+            clamped = _clamp_to_profile(data.get("position"), target_field)
+            if clamped is None:
+                raise ValueError(f"2MDV invalid curtain position: {data.get('position')!r}")
+            await context.async_send_service("opener", {"target": clamped})
+
+        return (
+            EntitySpec(
+                platform="cover",
+                key="curtain",
+                name=None,
+                state=cover_state,
+                metadata={},
+                actions={
+                    "open": _cover_open,
+                    "close": _cover_close,
+                    "stop": _cover_stop,
+                    "set_position": set_position,
+                },
+            ),
+        )
+
+    def _speed_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+
+        if context.has_service("switchSpeed") and _field(
+            profile, "switchSpeed", "action"
+        ) is not None:
+            gear_field = _field(profile, "switchSpeed", "action")
+            labels = _enum_labels(gear_field)
+            options: list[str] = []
+            for raw in (
+                option.get("enumVal") for option in gear_field.get("enumList", ()) or ()
+            ):
+                if raw is None:
+                    continue
+                label = labels.get(str(raw))
+                if label is None:
+                    continue
+                if label in options:
+                    label = f"{label} (rawValue)"
+                options.append(label)
+
+            def gear_state(device: DeviceContext) -> Mapping[str, Any]:
+                value = device.value("switchSpeed", "action")
+                if value is None or isinstance(value, bool):
+                    return {"current_option": None}
+                return {"current_option": labels.get(_enum_key(value) or "")}
+
+            async def select_gear(context: DeviceContext, data: Mapping[str, Any]) -> None:
+                value = _enum_payload(data.get("option") or "", gear_field)
+                if value is None:
+                    raise ValueError(f"2MDV unknown speed gear: {data.get('option')!r}")
+                await context.async_send_service("switchSpeed", {"action": value})
+
+            entities.append(
+                EntitySpec(
+                    platform="select",
+                    key="speed_gear",
+                    name="开合速度",
+                    state=gear_state,
+                    metadata={"options": tuple(options)},
+                    actions={"select_option": select_gear},
+                )
+            )
+
+        if context.has_service("speed") and _field(
+            profile, "speed", "motorSpeed"
+        ) is not None:
+            speed_field = _field(profile, "speed", "motorSpeed")
+            value_range = _profile_range(speed_field)
+            if value_range is not None:
+                minimum, maximum = value_range
+                step = _number(speed_field.get("step")) or 1.0
+
+                def speed_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _number(device.value("speed", "motorSpeed"))
+                    }
+
+                async def set_speed(context: DeviceContext, data: Mapping[str, Any]) -> None:
+                    clamped = _clamp_to_profile(data.get("value"), speed_field)
+                    if clamped is None:
+                        raise ValueError(f"2MDV invalid motor speed: {data.get('value')!r}")
+                    await context.async_send_service("speed", {"motorSpeed": clamped})
+
+                entities.append(
+                    EntitySpec(
+                        platform="number",
+                        key="motor_speed",
+                        name="无极调速",
+                        state=speed_state,
+                        metadata={
+                            "min": minimum,
+                            "max": maximum,
+                            "step": step,
+                            "unit": "%",
+                        },
+                        actions={"set_value": set_speed},
+                    )
+                )
+        return tuple(entities)
+
+    def _light_entity(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("lightSwitch"):
+            return ()
+        if _field(profile, "lightSwitch", "action") is None:
+            return ()
+
+        def light_state(device: DeviceContext) -> Mapping[str, Any]:
+            return {"is_on": _number(device.value("lightSwitch", "action")) == 1}
+
+        async def turn_on(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await context.async_send_service("lightSwitch", {"action": 1})
+
+        async def turn_off(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+            await context.async_send_service("lightSwitch", {"action": 0})
+
+        return (
+            EntitySpec(
+                platform="switch",
+                key="indicator",
+                name="指示灯",
+                state=light_state,
+                metadata={},
+                actions={"turn_on": turn_on, "turn_off": turn_off},
+            ),
+        )
+
+    def _button_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+
+        def button(
+            sid: str,
+            field_name: str,
+            value: Any,
+            key: str,
+            name: str,
+            guard_sid: str | None = None,
+        ) -> EntitySpec | None:
+            target_sid = guard_sid or sid
+            if not context.has_service(target_sid):
+                return None
+            if _field(profile, sid, field_name) is None:
+                return None
+
+            async def press(context: DeviceContext, _data: Mapping[str, Any]) -> None:
+                await context.async_send_service(sid, {field_name: value})
+
+            return EntitySpec(
+                platform="button",
+                key=key,
+                name=name,
+                state=lambda device: {},
+                metadata={},
+                actions={"press": press},
+            )
+
+        # placeMemory.action: write semantics from the bundle's validation
+        # schema (mean ["设置限位","清除全部限位"], range [0,1]); the H5 only
+        # displays placeMemory.code. 清除 wipes travel limits — deliberate use.
+        for sid, field_name, value, key, name, guard in (
+            ("placeMemory", "action", 0, "set_limit", "设置限位", "placeMemory"),
+            ("placeMemory", "action", 1, "clear_limits", "清除全部限位", "placeMemory"),
+            ("changeDirection", "action", 1, "reverse_direction", "更换设备转向", "changeDirection"),
+            ("selfCheck", "on", 1, "self_check", "功能检测", "selfCheck"),
+        ):
+            spec = button(sid, field_name, value, key, name, guard)
+            if spec is not None:
+                entities.append(spec)
+        return tuple(entities)
+
+    def _fault_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        if context.has_service("faultDetection"):
+            code_field = _field(profile, "faultDetection", "code")
+            if code_field is not None:
+
+                def fault_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _enum_text(
+                            code_field,
+                            device.value("faultDetection", "code"),
+                        )
+                    }
+
+                entities.append(
+                    EntitySpec(
+                        platform="sensor",
+                        key="fault_status",
+                        name="故障状态",
+                        state=fault_state,
+                        metadata={},
+                    )
+                )
+
+            status_field = _field(profile, "faultDetection", "status")
+            if status_field is not None:
+
+                def problem_state(device: DeviceContext) -> Mapping[str, Any]:
+                    # Profile enum: 1=设备运行异常, 0=运行正常，无错误
+                    status = _number(device.value("faultDetection", "status"))
+                    return {"is_on": None if status is None else status == 1}
+
+                entities.append(
+                    EntitySpec(
+                        platform="binary_sensor",
+                        key="fault_problem",
+                        name="故障告警",
+                        state=problem_state,
+                        metadata={"device_class": "problem"},
+                    )
+                )
+
+        if context.has_service("placeMemory"):
+            limit_field = _field(profile, "placeMemory", "code")
+            if limit_field is not None:
+
+                def limit_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _enum_text(
+                            limit_field,
+                            device.value("placeMemory", "code"),
+                        )
+                    }
+
+                entities.append(
+                    EntitySpec(
+                        platform="sensor",
+                        key="limit_status",
+                        name="限位状态",
+                        state=limit_state,
+                        metadata={},
+                    )
+                )
+        return tuple(entities)
+
+    def _net_info_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("netInfo"):
+            return ()
+
+        entities: list[EntitySpec] = []
+
+        rssi_field = _field(profile, "netInfo", "RSSI")
+        if rssi_field is not None:
+
+            def rssi_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value("netInfo", "RSSI"))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_rssi",
+                    name="信号强度",
+                    state=rssi_state,
+                    metadata={"state_class": "measurement"},
+                )
+            )
+
+        intensity_field = _field(profile, "netInfo", "intensity")
+        if intensity_field is not None:
+
+            def intensity_state(device: DeviceContext) -> Mapping[str, Any]:
+                # Profile enum: 20/40/60/80/100 -> 0..4 格信号
+                return {
+                    "native_value": _enum_text(
+                        intensity_field,
+                        device.value("netInfo", "intensity"),
+                    )
+                }
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_level",
+                    name="信号等级",
+                    state=intensity_state,
+                    metadata={},
+                )
+            )
+
+        for char_name, key, label in (
+            ("SSID", "wifi_ssid", "Wi-Fi 名称"),
+            ("IP", "wifi_ip", "IP 地址"),
+            ("BSSID", "wifi_bssid", "BSSID"),
+        ):
+            if _field(profile, "netInfo", char_name) is None:
+                continue
+
+            def text_state(device: DeviceContext, name: str = char_name) -> Mapping[str, Any]:
+                return {"native_value": _text(device.value("netInfo", name))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key=key,
+                    name=label,
+                    state=text_state,
+                    metadata={},
+                )
+            )
+
+        return tuple(entities)
+
+
+ADAPTER = Product2MDVAdapter()

--- a/custom_components/huawei_smarthome/device_adapters/prod_2ojq.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2ojq.py
@@ -1,0 +1,500 @@
+"""User-contributed protocol for Huawei product 2OJQ (电小酷智能转换插座 CP1-HW-A).
+
+Profile: switch.on / indicator.on / childLockSwitch.on /
+ProtectionSwitch.ProtectionSwitch / memorySwitch.status (enum 0关/1开/2保持) /
+ChargingProtection.{ProtectionPower 0..200W step2, ProtectDuration 0..300min step5} /
+power.current (W) / electric.{voltage V, current mA, totalElectricity kWh} /
+commonFaultDetection.{code 0/100/102, status} / netInfo diagnostics.
+
+H5 evidence (h5_001 template-style unminified bundle, socket theme):
+- CommonStatusbar1.onclick -> setDeviceInfo({switch: {on: N}}); its labelObj
+  names switch_on "电源开关", the outlet master switch.
+- GeneralBoolSwitchCard--c4 (指示灯开关) -> setDeviceInfo({indicator: {on: N}}).
+- GeneralBoolIconCard--e2 (童锁开关) -> setDeviceInfo({childLockSwitch: {on: N}}).
+- GeneralBoolSwitchCard--b3 (充电保护) -> setDeviceInfo({ProtectionSwitch:
+  {ProtectionSwitch: N}}) (getoptions obj mirrors the nested shape).
+- GeneralEnumDroplistCard1 (断电记忆) -> setDeviceInfo({memorySwitch:
+  {status: v}}), droplist 0关/1开/2保持上次状态 (same labels as Profile).
+- GeneralIntCircular--c1 (保护功率) -> setDeviceInfo({ChargingProtection:
+  {ProtectionPower: N}}), H5 slider 0..200 step 2 unit W.
+- GeneralIntCircular--b2 (保护时间) -> setDeviceInfo({ChargingProtection:
+  {ProtectDuration: N}}), H5 slider 0..300 step 5 unit min.
+- Statusbar fullsdata confirms power.current 当前功率 W, electric.voltage 电压 V,
+  electric.current 电流 mA; TotalChart1 renders 总用电量 (totalElectricity kWh).
+- GeneralWarn1 maps commonFaultDetection.code 100=过载保护 / 102=过压保护.
+
+Not exposed (宁可不出):
+- timer / delay: list-management protocols ({timer|delay: {action: 0/1/2,
+  timer|delay: [...]}}) confirmed in sdk.js ({delay:{delay:[{para:"on",...,
+  sid:"switch"}],action:1}} create / action:0 update / action:2 delete), but
+  they are schedule-record CRUD, not simple device controls; HA automations
+  cover this better and a guessed time format risks bogus timers.
+- update service: no UI/handler anywhere in this bundle (index.js handlers
+  only cover the cards above; sdk.js setDeviceInfo sites are timer/delay/
+  statusbar leftovers).
+- ruleData hides the ChargingProtection sliders when ProtectionSwitch=0:
+  that is a pure UI gate, not replicated here (persistent HA entities cannot
+  be hidden dynamically, and gating writes would break usable features).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+
+def _service(profile: Mapping[str, Any], sid: str) -> Mapping[str, Any] | None:
+    for service in profile.get("services", ()):
+        if isinstance(service, Mapping) and service.get("serviceId") == sid:
+            return service
+    return None
+
+
+def _field(
+    profile: Mapping[str, Any],
+    sid: str,
+    name: str,
+) -> Mapping[str, Any] | None:
+    service = _service(profile, sid)
+    if service is None:
+        return None
+    for field in service.get("characteristics", ()):
+        if isinstance(field, Mapping) and field.get("characteristicName") == name:
+            return field
+    return None
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(number) if number.is_integer() else number
+
+
+def _bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.casefold() in {"1", "true", "on"}:
+            return True
+        if value.casefold() in {"0", "false", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _text(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        return value or None
+    return str(value)
+
+
+def _profile_range(field: Mapping[str, Any]) -> tuple[float, float] | None:
+    minimum = _number(field.get("min"))
+    maximum = _number(field.get("max"))
+    if minimum is None or maximum is None or maximum <= minimum:
+        return None
+    return float(minimum), float(maximum)
+
+
+def _clamp_to_profile(value: Any, field: Mapping[str, Any]) -> int | float | None:
+    number = _number(value)
+    value_range = _profile_range(field)
+    if number is None or value_range is None:
+        return number
+    minimum, maximum = value_range
+    number = min(max(float(number), minimum), maximum)
+    return int(number) if number.is_integer() else number
+
+
+def _enum_labels(field: Mapping[str, Any]) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for option in field.get("enumList", ()) or ():
+        if not isinstance(option, Mapping):
+            continue
+        key = option.get("enumVal")
+        if key is None:
+            continue
+        labels[str(key)] = str(option.get("descCh") or option.get("enumVal"))
+    return labels
+
+
+def _enum_key(value: Any) -> str | None:
+    number = _number(value)
+    return str(int(number)) if number is not None else _text(value)
+
+
+def _enum_text(field: Mapping[str, Any], value: Any) -> str | None:
+    """Map a raw characteristic value to its Profile enum label.
+
+    Unknown values return None (unknown) instead of guessing a label.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    return _enum_labels(field).get(_enum_key(value) or "")
+
+
+def _enum_payload(value: str, field: Mapping[str, Any]) -> Any:
+    """Convert a selected label back to the wire value.
+
+    Numeric enum values are sent as ints, non-numeric ones verbatim.
+    """
+    labels = _enum_labels(field)
+    for key, label in labels.items():
+        if label == value:
+            try:
+                return int(float(key))
+            except (TypeError, ValueError):
+                return key
+    return None
+
+
+def _flag_state(sid: str, field_name: str):
+    def state(device: DeviceContext) -> Mapping[str, Any]:
+        return {"is_on": _bool(device.value(sid, field_name))}
+
+    return state
+
+
+def _flag_action(sid: str, field_name: str, on_value: Any):
+    """Pre-bind the written value: switch platforms invoke actions with data={}."""
+
+    async def action(context: DeviceContext, data: Mapping[str, Any]) -> None:
+        await context.async_send_service(sid, {field_name: on_value})
+
+    return action
+
+
+class Product2OJQAdapter:
+    prod_id = "2OJQ"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None:
+            return ()
+        entities: list[EntitySpec] = []
+        entities.extend(self._switch_entities(context, profile))
+        entities.extend(self._memory_entity(context, profile))
+        entities.extend(self._charging_protection_entities(context, profile))
+        entities.extend(self._metering_entities(context, profile))
+        entities.extend(self._fault_entities(context, profile))
+        entities.extend(self._net_info_entities(context, profile))
+        return tuple(entities)
+
+    def _switch_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        # (sid, field, key, name or None). H5 labelObj: switch_on=电源开关,
+        # indicator_on=指示灯开关, childLockSwitch_on=童锁开关,
+        # ProtectionSwitch_ProtectionSwitch=充电保护. Names drop the redundant
+        # platform word ("开关") per naming conventions.
+        specs = (
+            ("switch", "on", "outlet", None),
+            ("indicator", "on", "indicator", "指示灯"),
+            ("childLockSwitch", "on", "child_lock", "童锁"),
+            ("ProtectionSwitch", "ProtectionSwitch", "charging_protection", "充电保护"),
+        )
+        for sid, field_name, key, name in specs:
+            if not context.has_service(sid):
+                continue
+            if _field(profile, sid, field_name) is None:
+                continue
+            entities.append(
+                EntitySpec(
+                    platform="switch",
+                    key=key,
+                    name=name,
+                    state=_flag_state(sid, field_name),
+                    metadata={},
+                    actions={
+                        "turn_on": _flag_action(sid, field_name, 1),
+                        "turn_off": _flag_action(sid, field_name, 0),
+                    },
+                )
+            )
+        return tuple(entities)
+
+    def _memory_entity(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("memorySwitch"):
+            return ()
+        status_field = _field(profile, "memorySwitch", "status")
+        if status_field is None:
+            return ()
+        labels = _enum_labels(status_field)
+        # Keep Profile order (0关/1开/2保持上次状态), de-duplicate display labels.
+        options: list[str] = []
+        for raw in (option.get("enumVal") for option in status_field.get("enumList", ()) or ()):
+            if raw is None:
+                continue
+            label = labels.get(str(raw))
+            if label is None:
+                continue
+            if label in options:
+                label = f"{label} (rawValue)"
+            options.append(label)
+
+        def state(device: DeviceContext) -> Mapping[str, Any]:
+            value = device.value("memorySwitch", "status")
+            if value is None or isinstance(value, bool):
+                return {"current_option": None}
+            label = labels.get(_enum_key(value) or "")
+            return {"current_option": label}
+
+        async def select_option(context: DeviceContext, data: Mapping[str, Any]) -> None:
+            value = _enum_payload(data.get("option") or "", status_field)
+            if value is None:
+                raise ValueError(f"2OJQ unknown memorySwitch option: {data.get('option')!r}")
+            await context.async_send_service("memorySwitch", {"status": value})
+
+        return (
+            EntitySpec(
+                platform="select",
+                key="memory_switch",
+                name="断电记忆",
+                state=state,
+                metadata={"options": tuple(options)},
+                actions={"select_option": select_option},
+            ),
+        )
+
+    def _charging_protection_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("ChargingProtection"):
+            return ()
+        entities: list[EntitySpec] = []
+        # H5 GeneralIntCircular sliders: 保护功率 0..200 step 2 W, 保护时间
+        # 0..300 step 5 min. Ranges/steps follow the Profile (identical values).
+        for field_name, key, name, unit in (
+            ("ProtectionPower", "protection_power", "保护功率", "W"),
+            ("ProtectDuration", "protection_duration", "保护时间", "min"),
+        ):
+            field = _field(profile, "ChargingProtection", field_name)
+            value_range = _profile_range(field or {})
+            if field is None or value_range is None:
+                continue
+            minimum, maximum = value_range
+            step = _number(field.get("step")) or 1.0
+
+            def state(device: DeviceContext, name: str = field_name) -> Mapping[str, Any]:
+                return {
+                    "native_value": _number(device.value("ChargingProtection", name))
+                }
+
+            async def set_value(
+                context: DeviceContext,
+                data: Mapping[str, Any],
+                field: Mapping[str, Any] = field,
+                field_name: str = field_name,
+            ) -> None:
+                clamped = _clamp_to_profile(data.get("value"), field)
+                if clamped is None:
+                    raise ValueError(f"2OJQ invalid {field_name} value: {data.get('value')!r}")
+                await context.async_send_service("ChargingProtection", {field_name: clamped})
+
+            entities.append(
+                EntitySpec(
+                    platform="number",
+                    key=key,
+                    name=name,
+                    state=state,
+                    metadata={
+                        "min": minimum,
+                        "max": maximum,
+                        "step": step,
+                        "unit": unit,
+                    },
+                    actions={"set_value": set_value},
+                )
+            )
+        return tuple(entities)
+
+    def _metering_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        # H5 statusbar fullsdata: power.current 当前功率 W, electric.voltage 电压 V,
+        # electric.current 电流 mA; TotalChart1 总用电量 (totalElectricity kWh).
+        # current stays a plain sensor: HA's current device class expects A,
+        # not the mA this device reports.
+        specs = (
+            ("power", "current", "power", "当前功率", "W", "power", "measurement"),
+            ("electric", "voltage", "voltage", "电压", "V", "voltage", "measurement"),
+            ("electric", "current", "current", "电流", "mA", None, "measurement"),
+            (
+                "electric",
+                "totalElectricity",
+                "total_energy",
+                "总用电量",
+                "kWh",
+                "energy",
+                "total_increasing",
+            ),
+        )
+        for sid, field_name, key, name, unit, device_class, state_class in specs:
+            if not context.has_service(sid):
+                continue
+            if _field(profile, sid, field_name) is None:
+                continue
+
+            def state(device: DeviceContext, name: str = sid, field: str = field_name) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value(name, field))}
+
+            metadata: dict[str, Any] = {"unit": unit, "state_class": state_class}
+            if device_class:
+                metadata["device_class"] = device_class
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key=key,
+                    name=name,
+                    state=state,
+                    metadata=metadata,
+                )
+            )
+        return tuple(entities)
+
+    def _fault_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        entities: list[EntitySpec] = []
+        if context.has_service("commonFaultDetection"):
+            code_field = _field(profile, "commonFaultDetection", "code")
+            if code_field is not None:
+
+                def fault_state(device: DeviceContext) -> Mapping[str, Any]:
+                    return {
+                        "native_value": _enum_text(
+                            code_field,
+                            device.value("commonFaultDetection", "code"),
+                        )
+                    }
+
+                entities.append(
+                    EntitySpec(
+                        platform="sensor",
+                        key="fault_status",
+                        name="故障状态",
+                        state=fault_state,
+                        metadata={},
+                    )
+                )
+
+            status_field = _field(profile, "commonFaultDetection", "status")
+            if status_field is not None:
+
+                def problem_state(device: DeviceContext) -> Mapping[str, Any]:
+                    # Profile enum: 1=设备运行异常, 0=运行正常，无错误
+                    status = _number(device.value("commonFaultDetection", "status"))
+                    return {"is_on": None if status is None else status == 1}
+
+                entities.append(
+                    EntitySpec(
+                        platform="binary_sensor",
+                        key="fault_problem",
+                        name="故障告警",
+                        state=problem_state,
+                        metadata={"device_class": "problem"},
+                    )
+                )
+        return tuple(entities)
+
+    def _net_info_entities(
+        self,
+        context: DeviceContext,
+        profile: Mapping[str, Any],
+    ) -> tuple[EntitySpec, ...]:
+        if not context.has_service("netInfo"):
+            return ()
+
+        entities: list[EntitySpec] = []
+
+        rssi_field = _field(profile, "netInfo", "RSSI")
+        if rssi_field is not None:
+
+            def rssi_state(device: DeviceContext) -> Mapping[str, Any]:
+                return {"native_value": _number(device.value("netInfo", "RSSI"))}
+
+            unit = _text(rssi_field.get("unit"))
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_rssi",
+                    name="信号强度",
+                    state=rssi_state,
+                    metadata={
+                        "unit": unit,
+                        "state_class": "measurement",
+                    },
+                )
+            )
+
+        intensity_field = _field(profile, "netInfo", "intensity")
+        if intensity_field is not None:
+
+            def intensity_state(device: DeviceContext) -> Mapping[str, Any]:
+                # Profile enum: 20/40/60/80/100 -> 0..4 格信号
+                return {
+                    "native_value": _enum_text(
+                        intensity_field,
+                        device.value("netInfo", "intensity"),
+                    )
+                }
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="wifi_level",
+                    name="信号等级",
+                    state=intensity_state,
+                    metadata={},
+                )
+            )
+
+        for char_name, key, label in (
+            ("SSID", "wifi_ssid", "Wi-Fi 名称"),
+            ("IP", "wifi_ip", "IP 地址"),
+            ("BSSID", "wifi_bssid", "BSSID"),
+        ):
+            if _field(profile, "netInfo", char_name) is None:
+                continue
+
+            def text_state(device: DeviceContext, name: str = char_name) -> Mapping[str, Any]:
+                return {"native_value": _text(device.value("netInfo", name))}
+
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key=key,
+                    name=label,
+                    state=text_state,
+                    metadata={},
+                )
+            )
+
+        return tuple(entities)
+
+
+ADAPTER = Product2OJQAdapter()

--- a/custom_components/huawei_smarthome/device_adapters/prod_zg10.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_zg10.py
@@ -1,0 +1,388 @@
+"""Product adapter for the OSLO-SS2 two-key smart switch (ZG10, 智能开关 2键).
+
+Vendor H5 bundle (``ZG10/h5_001``; ``app.js`` holds all logic, ``chunk_1.js``
+is the vendor lib) serves the OSLO switch family.  Unlike the EBOLON switch
+(2MH8) this H5 dispatches with the ``{sid, cid, value}`` helper, whose vuex
+action serialises to exactly the wire form ``{[sid]: {[cid]: value}}``:
+
+.. code-block:: js
+
+    setDevInfo({},{sid:e,cid:t,value:i,callback:n}){
+      window.hilink.setDeviceInfo("0", JSON.stringify({[e]:{[t]:i}}), ...)
+
+* ``switch1.on`` / ``switch2.on`` — the two relay outputs.  The home card's
+  ``onClickButton1``/``onClickButton2`` dispatch ``{switch1:{on: 0|1}}``
+  (``valueExchange`` inverts the current value) when the key mode is 1.
+* ``mode1.mode`` / ``mode2.mode`` (1 开关模式 / 2 场景模式) — the 按键管理
+  page's ``onRadioChange`` writes ``{mode1:{mode:N}}``.  The H5 i18n dict
+  names the values 开关模式/场景模式 ("按下按键执行场景，不再控制连接设备");
+  the Profile descCh says 联动模式 for 2 — the H5 label is used.
+* ``childLockSwitch.on`` — 按键锁定 toggle (i18n ``childLock`` = 按键锁定).
+* ``backlight.on`` — 指示灯 toggle (i18n ``backLight`` = 指示灯, same
+  reading as the OSLO-SP6 panel adapter ZG0E).
+* ``brightness.brightness`` — 指示灯亮度 slider, H5 ``range:[1,100]`` with
+  unit ``%``.  The Profile declares min 0 / max 20, which contradicts the
+  actual slider; the H5 range is used for the command clamp (values the
+  device reports outside 1-100 stay raw, only non-numerics become unknown).
+* ``memorySwitch.on`` — 断电记忆 toggle (bool 0/1, unlike the EBOLON
+  three-state ``memorySwitch.status``).
+* ``faultDetection.code`` — fault bitmask.  The H5 keeps the raw ``code``
+  as a bitmask and maps set-bit positions through ``faults[]``:
+  ``faults:[过温保护, 继电器故障]``, rendering unknown positions as
+  未知故障.  (Its banner additionally masks with ``2&code`` to only surface
+  the relay fault, which confirms the bitwise reading.)  ``code`` = 0 with
+  ``status`` = 0 means 正常.
+
+Deliberately NOT exposed:
+
+* ``scene`` — ``num``/``DoubleClick``/``LongClick`` are *event counters*
+  (the H5 reads them as click history records with values 1/2 = which key,
+  via ``getDevHistory``; ``DoubleClick`` is never referenced anywhere in
+  the bundle).  Scene binding itself is managed by the app's
+  ScenarioManager / gateway commands, not by a device write.
+* ``button1`` / ``button2`` — only ``name`` (rename, belongs to HA) and
+  ``num`` (internal key-count bookkeeping).
+* ``switch1.name`` / ``switch2.name`` — renaming belongs to HA.
+* ``reboot`` — the H5 writes ``{reboot:{action:2, devList:[{sn}]}}``
+  (gateway-attached batch reboot); the descriptor has no ``sn`` and
+  degrading to ``action:0`` would reboot the whole gateway.  Same ruling
+  as the ZG1Y / ZG0E adapters.
+* ``update`` — OTA (check/launch upgrade), app-managed.
+* ``switchN.inversion`` — never referenced in the bundle.
+* ``backlightMode`` — the H5 updateState knows this sid but the Profile has
+  no such service (internal relay/indicator wiring state).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .api import EntitySpec
+from .context import DeviceContext
+
+_SWITCH_SIDS = ("switch1", "switch2")
+_SWITCH_FIELD = "on"
+
+_MODE_FIELD = "mode"
+_MODE_VALUES = (1, 2)
+_MODE_OPTIONS = ("开关模式", "场景模式")  # H5 i18n; Profile descCh: 联动模式
+
+_LOCK_SID = "childLockSwitch"
+_BACKLIGHT_SID = "backlight"
+_MEMORY_SID = "memorySwitch"
+_FLAG_FIELD = "on"
+
+_BRIGHTNESS_SID = "brightness"
+_BRIGHTNESS_FIELD = "brightness"
+_BRIGHTNESS_RANGE = (1.0, 100.0)  # H5 slider range:[1,100] unit %
+_BRIGHTNESS_UNIT = "%"
+
+_FAULT_SID = "faultDetection"
+_FAULT_CODE_FIELD = "code"
+# H5 faults[] indexed by bit position of the code bitmask.
+_FAULT_BITS = ((1, "过温保护"), (2, "继电器故障"))
+
+
+def _service(profile: Any, sid: str) -> Any:
+    if profile is None:
+        return None
+    for service in profile.get("services", ()):
+        if service.get("serviceId") == sid:
+            return service
+    return None
+
+
+def _field(profile: Any, sid: str, name: str) -> Mapping[str, Any] | None:
+    service = _service(profile, sid)
+    if service is None:
+        return None
+    for characteristic in service.get("characteristics", ()):
+        if characteristic.get("characteristicName") == name:
+            return characteristic
+    return None
+
+
+def _flag_value(raw: Any) -> bool | None:
+    """Reported switch value → bool; anything outside 0/1 stays unknown."""
+
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    try:
+        number = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if number == 1:
+        return True
+    if number == 0:
+        return False
+    return None
+
+
+def _flag_action(sid: str, value: int):
+    async def action(ctx: DeviceContext, data: Mapping[str, Any]) -> None:
+        del data
+        await ctx.async_send_service(sid, {_FLAG_FIELD: value})
+
+    return action
+
+
+def _enum_state(
+    context: DeviceContext,
+    sid: str,
+    field: str,
+    options: tuple[str, ...],
+    values: tuple[int, ...],
+) -> str | None:
+    """Map a reported enum value onto its label; unknown values stay unknown."""
+
+    raw = context.value(sid, field)
+    if raw is None:
+        return None
+    try:
+        number = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if number not in values:
+        return None
+    return dict(zip(values, options)).get(number)
+
+
+def _enum_payload(
+    option: str, options: tuple[str, ...], values: tuple[int, ...]
+) -> int | None:
+    try:
+        return values[options.index(option)]
+    except ValueError:
+        return None
+
+
+def _number(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _fault_state(context: DeviceContext) -> str | None:
+    """Decompose the fault bitmask exactly like the H5's ``faultInfoList``."""
+
+    raw = context.value(_FAULT_SID, _FAULT_CODE_FIELD)
+    if raw is None:
+        return None
+    try:
+        code = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if code == 0:
+        return "正常"
+    labels: list[str] = []
+    known = 0
+    for bit, label in _FAULT_BITS:
+        if code & bit:
+            labels.append(label)
+            known |= bit
+    unknown = code & ~known
+    if unknown:
+        highest = unknown.bit_length()
+        labels.append(f"未知({highest - 1})")
+    return "、".join(labels)
+
+
+def _enum_select(
+    key: str,
+    name: str,
+    sid: str,
+    field: str,
+    options: tuple[str, ...],
+    values: tuple[int, ...],
+) -> EntitySpec:
+    async def action(ctx: DeviceContext, data: Mapping[str, Any]) -> None:
+        option = data.get("option")
+        if not isinstance(option, str):
+            return
+        value = _enum_payload(option, options, values)
+        if value is not None:
+            await ctx.async_send_service(sid, {field: value})
+
+    return EntitySpec(
+        platform="select",
+        key=key,
+        name=name,
+        state=lambda ctx, _sid=sid, _f=field, _o=options, _v=values: {
+            "current_option": _enum_state(ctx, _sid, _f, _o, _v)
+        },
+        metadata={"options": list(options)},
+        actions={"select_option": action},
+    )
+
+
+class ProductZG10Adapter:
+    """OSLO-SS2 two-key smart switch (ZG10)."""
+
+    prod_id = "ZG10"
+
+    def entities(self, context: DeviceContext) -> tuple[EntitySpec, ...]:
+        profile = context.profile
+        if profile is None:
+            return ()
+
+        entities: list[EntitySpec] = []
+
+        # --- relay outputs --------------------------------------------------
+        for index, sid in enumerate(_SWITCH_SIDS, start=1):
+            if not context.has_service(sid) or _field(
+                profile, sid, _SWITCH_FIELD
+            ) is None:
+                continue
+            entities.append(
+                EntitySpec(
+                    platform="switch",
+                    key=f"switch_{index}",
+                    name=f"开关{'一二'[index - 1]}",
+                    state=lambda ctx, _sid=sid: {
+                        "is_on": _flag_value(ctx.value(_sid, _SWITCH_FIELD))
+                    },
+                    metadata={},
+                    actions={
+                        "turn_on": _flag_action(sid, 1),
+                        "turn_off": _flag_action(sid, 0),
+                    },
+                )
+            )
+
+        # --- per-key mode ---------------------------------------------------
+        for index, sid in enumerate(("mode1", "mode2"), start=1):
+            if not context.has_service(sid) or _field(
+                profile, sid, _MODE_FIELD
+            ) is None:
+                continue
+            entities.append(
+                _enum_select(
+                    f"key_{index}_mode",
+                    f"按键{'一二'[index - 1]}模式",
+                    sid,
+                    _MODE_FIELD,
+                    _MODE_OPTIONS,
+                    _MODE_VALUES,
+                )
+            )
+
+        # --- key lock -------------------------------------------------------
+        if context.has_service(_LOCK_SID) and _field(
+            profile, _LOCK_SID, _FLAG_FIELD
+        ) is not None:
+            entities.append(
+                EntitySpec(
+                    platform="switch",
+                    key="key_lock",
+                    name="按键锁定",
+                    state=lambda ctx: {
+                        "is_on": _flag_value(ctx.value(_LOCK_SID, _FLAG_FIELD))
+                    },
+                    metadata={},
+                    actions={
+                        "turn_on": _flag_action(_LOCK_SID, 1),
+                        "turn_off": _flag_action(_LOCK_SID, 0),
+                    },
+                )
+            )
+
+        # --- indicator light ------------------------------------------------
+        if context.has_service(_BACKLIGHT_SID) and _field(
+            profile, _BACKLIGHT_SID, _FLAG_FIELD
+        ) is not None:
+            entities.append(
+                EntitySpec(
+                    platform="switch",
+                    key="indicator_light",
+                    name="指示灯",
+                    state=lambda ctx: {
+                        "is_on": _flag_value(ctx.value(_BACKLIGHT_SID, _FLAG_FIELD))
+                    },
+                    metadata={},
+                    actions={
+                        "turn_on": _flag_action(_BACKLIGHT_SID, 1),
+                        "turn_off": _flag_action(_BACKLIGHT_SID, 0),
+                    },
+                )
+            )
+
+        # --- indicator brightness -------------------------------------------
+        if context.has_service(_BRIGHTNESS_SID) and _field(
+            profile, _BRIGHTNESS_SID, _BRIGHTNESS_FIELD
+        ) is not None:
+            async def _brightness_action(ctx: DeviceContext, data: Mapping[str, Any]) -> None:
+                value = _number(data.get("value"))
+                if value is not None:
+                    clamped = int(_clamp(value, *_BRIGHTNESS_RANGE))
+                    await ctx.async_send_service(
+                        _BRIGHTNESS_SID, {_BRIGHTNESS_FIELD: clamped}
+                    )
+
+            entities.append(
+                EntitySpec(
+                    platform="number",
+                    key="indicator_brightness",
+                    name="指示灯亮度",
+                    state=lambda ctx: {
+                        "native_value": _number(
+                            ctx.value(_BRIGHTNESS_SID, _BRIGHTNESS_FIELD)
+                        )
+                    },
+                    metadata={
+                        "min": _BRIGHTNESS_RANGE[0],
+                        "max": _BRIGHTNESS_RANGE[1],
+                        "step": 1.0,
+                        "unit": _BRIGHTNESS_UNIT,
+                    },
+                    actions={"set_value": _brightness_action},
+                )
+            )
+
+        # --- power-loss memory ----------------------------------------------
+        if context.has_service(_MEMORY_SID) and _field(
+            profile, _MEMORY_SID, _FLAG_FIELD
+        ) is not None:
+            entities.append(
+                EntitySpec(
+                    platform="switch",
+                    key="power_loss_memory",
+                    name="断电记忆",
+                    state=lambda ctx: {
+                        "is_on": _flag_value(ctx.value(_MEMORY_SID, _FLAG_FIELD))
+                    },
+                    metadata={},
+                    actions={
+                        "turn_on": _flag_action(_MEMORY_SID, 1),
+                        "turn_off": _flag_action(_MEMORY_SID, 0),
+                    },
+                )
+            )
+
+        # --- fault state ------------------------------------------------------
+        if context.has_service(_FAULT_SID) and _field(
+            profile, _FAULT_SID, _FAULT_CODE_FIELD
+        ) is not None:
+            entities.append(
+                EntitySpec(
+                    platform="sensor",
+                    key="fault_state",
+                    name="故障状态",
+                    state=lambda ctx: {"native_value": _fault_state(ctx)},
+                    metadata={},
+                    actions={},
+                )
+            )
+
+        return tuple(entities)
+
+
+ADAPTER = ProductZG10Adapter()

--- a/custom_components/huawei_smarthome/light.py
+++ b/custom_components/huawei_smarthome/light.py
@@ -39,10 +39,18 @@ class HuaweiAdapterLight(LightEntity):
         self._attr_name = spec.name or context.name
         self._attr_has_entity_name = True
         self._attr_should_poll = False
-        modes = metadata.get("supported_color_modes", {"onoff"})
-        self._attr_supported_color_modes = {
-            ColorMode(mode) for mode in modes
+        modes = {
+            ColorMode(mode) for mode in metadata.get("supported_color_modes", {"onoff"})
         }
+        # HA >= 2024.7 rejects supported_color_modes that combine ONOFF or
+        # BRIGHTNESS with real color modes ("sets invalid supported color
+        # modes"); both are implied by any other color mode, so drop them.
+        advanced = modes - {ColorMode.ONOFF, ColorMode.BRIGHTNESS, ColorMode.WHITE}
+        if advanced:
+            modes = advanced | (modes & {ColorMode.WHITE})
+        elif not modes:
+            modes = {ColorMode.ONOFF}
+        self._attr_supported_color_modes = modes
         if metadata.get("min_color_temp_kelvin") is not None:
             self._attr_min_color_temp_kelvin = int(
                 metadata["min_color_temp_kelvin"]


### PR DESCRIPTION
## 新增产品适配器（5 个）

| 设备 | 实体数 | 平台 |
|---|---|---|
| ZG10 OSLO-SS2 2键面板 | 9 | switch/select/number/sensor |
| 2I7K 欧普照明驱动 | 8 | light/sensor/binary_sensor |
| 2OJQ 电小酷智能转换插座 | 18 | switch/select/number/sensor/binary_sensor |
| 124U 正泰智能插座 | 10 | switch/sensor/binary_sensor |
| 2MDV 杜亚 PLC 开合帘电机 | 16 | **cover**(首个)/select/number/button/sensor/binary_sensor |

## 修复：light 平台 supported_color_modes 归一化

HA >= 2024.7 拒绝 ONOFF/BRIGHTNESS 与真实颜色模式混搭（实体被静默 abort，日志只有一条不含详情的 Error adding entity）。light.py 现对 metadata 声明自动归一化，同时修复存量适配器的同类问题。

全部适配器基于厂商 H5 包下发证据链（setDeviceInfo payload / 内置校验 schema / i18n）核实，无证据功能按"宁可不出"原则跳过；每个适配器附带离线 verify 脚本（37~67 项断言）全数通过。