### PR TITLE
fix: normalize adapter-declared supported color modes for light platform

### DIFF
--- a/custom_components/huawei_smarthome/light.py
+++ b/custom_components/huawei_smarthome/light.py
@@ -10,6 +10,7 @@ from homeassistant.components.light import (
     ATTR_RGB_COLOR,
     ColorMode,
     LightEntity,
+    filter_supported_color_modes,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -40,17 +41,13 @@ class HuaweiAdapterLight(LightEntity):
         self._attr_has_entity_name = True
         self._attr_should_poll = False
         modes = {
-            ColorMode(mode) for mode in metadata.get("supported_color_modes", {"onoff"})
+            ColorMode(mode)
+            for mode in metadata.get("supported_color_modes", {"onoff"})
         }
-        # HA >= 2024.7 rejects supported_color_modes that combine ONOFF or
-        # BRIGHTNESS with real color modes ("sets invalid supported color
-        # modes"); both are implied by any other color mode, so drop them.
-        advanced = modes - {ColorMode.ONOFF, ColorMode.BRIGHTNESS, ColorMode.WHITE}
-        if advanced:
-            modes = advanced | (modes & {ColorMode.WHITE})
-        elif not modes:
-            modes = {ColorMode.ONOFF}
-        self._attr_supported_color_modes = modes
+        # Use HA's own capability normalization.  Product adapters still
+        # declare the device capability; this only removes HA-implied ONOFF
+        # and BRIGHTNESS modes before LightEntity validates the set.
+        self._attr_supported_color_modes = filter_supported_color_modes(modes)
         if metadata.get("min_color_temp_kelvin") is not None:
             self._attr_min_color_temp_kelvin = int(
                 metadata["min_color_temp_kelvin"]

--- a/custom_components/huawei_smarthome/light.py
+++ b/custom_components/huawei_smarthome/light.py
@@ -39,10 +39,18 @@ class HuaweiAdapterLight(LightEntity):
         self._attr_name = spec.name or context.name
         self._attr_has_entity_name = True
         self._attr_should_poll = False
-        modes = metadata.get("supported_color_modes", {"onoff"})
-        self._attr_supported_color_modes = {
-            ColorMode(mode) for mode in modes
+        modes = {
+            ColorMode(mode) for mode in metadata.get("supported_color_modes", {"onoff"})
         }
+        # HA >= 2024.7 rejects supported_color_modes that combine ONOFF or
+        # BRIGHTNESS with real color modes ("sets invalid supported color
+        # modes"); both are implied by any other color mode, so drop them.
+        advanced = modes - {ColorMode.ONOFF, ColorMode.BRIGHTNESS, ColorMode.WHITE}
+        if advanced:
+            modes = advanced | (modes & {ColorMode.WHITE})
+        elif not modes:
+            modes = {ColorMode.ONOFF}
+        self._attr_supported_color_modes = modes
         if metadata.get("min_color_temp_kelvin") is not None:
             self._attr_min_color_temp_kelvin = int(
                 metadata["min_color_temp_kelvin"]


### PR DESCRIPTION
## Summary
HA 2026.9 rejects a light entity whose `supported_color_modes` mixes ONOFF/BRIGHTNESS with real color modes (COLOR_TEMP/RGB/XY/HS) — the entity registration aborts with "sets invalid supported color modes" and the light silently never appears.

Product adapters declare the raw Profile combination (e.g. `{color_temp, brightness}`), so `HuaweiAdapterLight` now normalizes it: when any real color mode is present, ONOFF/BRIGHTNESS are stripped, so `{color_temp, brightness}` → `{color_temp}`.

This also revives older adapters that declare `{onoff, color_temp}`.
#44 

## Testing
- Offline regression suites for all existing adapters pass (62/62, 37/37, 67/67, 37/37, 54/54).
- Verified on a live HA 2026.9 instance: affected OPPLE drive (2I7K) lights now register correctly after reload.
