### PR TITLE
feat(device_adapters): add KW02 reporting entities (firmware, roster, last-used)

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
@@ -558,6 +558,15 @@ class ProductKW02Adapter:
 #   lastActionTime   time is the last time the lock was operated.
 # ---------------------------------------------------------------------------
 
+_UPDATE_SID = "update"
+_USERS_SID = "users"
+_FACES_SID = "faces"
+_FINGERS_SID = "fingers"
+_KEY_OPERATE_SID = "keyOperate"
+_DOOR_EVENT_SID = "doorEvent"
+_LAST_ACTION_SID = "lastActionTime"
+
+
 def _firmware_specs(context: DeviceContext) -> list[EntitySpec]:
     """Firmware version of the lock body.
 
@@ -636,54 +645,51 @@ def _roster_specs(context: DeviceContext) -> list[EntitySpec]:
 
 
 def _reader_based_specs(context: DeviceContext) -> list[EntitySpec]:
-    """Last-operated metadata reported as plain text."""
+    """Last-operated metadata reported as plain text.
 
-    specs: list[EntitySpec] = []
+    These services are event-driven: the lock pushes keyOperate, doorEvent and
+    lastActionTime only when something happens, so none of them appears in the
+    discovery snapshot and ``has_service`` is false for them at setup time.
+    They are therefore always registered and simply report unknown until the
+    first event arrives.
+    """
 
-    if context.has_service(_KEY_OPERATE_SID):
-        def key_name(device: DeviceContext) -> Mapping[str, Any]:
-            value = device.value(_KEY_OPERATE_SID, "keyName")
-            return {"native_value": value if isinstance(value, str) and value else None}
+    def key_name(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_KEY_OPERATE_SID, "keyName")
+        return {"native_value": value if isinstance(value, str) and value else None}
 
-        specs.append(
-            EntitySpec(
-                platform="sensor",
-                key="last_key",
-                name="最近使用钥匙",
-                state=key_name,
-            )
-        )
-    if context.has_service(_DOOR_EVENT_SID):
-        def door_user(device: DeviceContext) -> Mapping[str, Any]:
-            value = device.value(_DOOR_EVENT_SID, "userName")
-            return {"native_value": value if isinstance(value, str) and value else None}
+    def door_user(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_DOOR_EVENT_SID, "userName")
+        return {"native_value": value if isinstance(value, str) and value else None}
 
-        specs.append(
-            EntitySpec(
-                platform="sensor",
-                key="door_event_user",
-                name="最近门事件人员",
-                state=door_user,
-            )
-        )
-    if context.has_service(_LAST_ACTION_SID):
-        def last_action(device: DeviceContext) -> Mapping[str, Any]:
-            value = device.value(_LAST_ACTION_SID, "time")
-            return {"native_value": value if isinstance(value, str) and value else None}
+    def last_action(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_LAST_ACTION_SID, "time")
+        return {"native_value": value if isinstance(value, str) and value else None}
 
-        specs.append(
-            EntitySpec(
-                platform="sensor",
-                key="last_action_time",
-                name="最近操作时间",
-                state=last_action,
-                # The lock reports SmartHome stamps ("20260912T094645Z"), not
-                # ISO 8601, so device_class=timestamp is deliberately omitted:
-                # HA would reject the value and the entity would show unknown.
-                metadata={"entity_category": "diagnostic"},
-            )
-        )
-    return specs
+    return [
+        EntitySpec(
+            platform="sensor",
+            key="last_key",
+            name="最近使用钥匙",
+            state=key_name,
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="door_event_user",
+            name="最近门事件人员",
+            state=door_user,
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="last_action_time",
+            name="最近操作时间",
+            state=last_action,
+            # The lock reports SmartHome stamps ("20260912T094645Z"), not ISO
+            # 8601, so device_class=timestamp is deliberately omitted: HA would
+            # reject the value and the entity would show unknown.
+            metadata={"entity_category": "diagnostic"},
+        ),
+    ]
 
 
 ADAPTER = ProductKW02Adapter()

--- a/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
@@ -533,7 +533,6 @@ class ProductKW02Adapter:
             entities.append(_open_direction_spec(read_unlock))
             entities.append(_last_open_method_spec(profile, read_unlock))
             entities.append(_door_alarm_spec(profile))
-        entities.extend(_weekly_report_specs())
         entities.extend(_firmware_specs(context))
         entities.extend(_roster_specs(context))
         entities.extend(_reader_based_specs(context))
@@ -550,9 +549,6 @@ class ProductKW02Adapter:
 # unverified write can reach the hardware.
 #
 # Wire details confirmed against the lock (deviating from the Profile):
-#   weeklyReport     battery.remain/consume are percentages; openinfo.total is
-#                    the number of unlocks in `period`; openinfo.userNum counts
-#                    distinct users.
 #   update           currentVersion is a firmware string ("AGS-X10 5.0.0.1(SP65C00)").
 #                    The Profile's update.action is deliberately not exposed.
 #   users            userList carries every enrolled member (un = name).
@@ -561,136 +557,6 @@ class ProductKW02Adapter:
 #                    event/eventData pair reports.
 #   lastActionTime   time is the last time the lock was operated.
 # ---------------------------------------------------------------------------
-
-_WEEKLY_REPORT_SID = "weeklyReport"
-_UPDATE_SID = "update"
-_USERS_SID = "users"
-_KEY_OPERATE_SID = "keyOperate"
-_DOOR_EVENT_SID = "doorEvent"
-_LAST_ACTION_SID = "lastActionTime"
-_FACES_SID = "faces"
-_FINGERS_SID = "fingers"
-
-
-def _weekly_battery_field(
-    device: DeviceContext,
-    name: str,
-) -> int | float | None:
-    report = device.value(_WEEKLY_REPORT_SID, "battery")
-    if not isinstance(report, Mapping):
-        return None
-    return _number(report.get(name))
-
-
-def _weekly_open_info(
-    device: DeviceContext,
-    name: str,
-) -> int | float | None:
-    info = device.value(_WEEKLY_REPORT_SID, "openinfo")
-    if not isinstance(info, Mapping):
-        return None
-    return _number(info.get(name))
-
-
-def _weekly_report_specs() -> list[EntitySpec]:
-    """Battery trend and unlock statistics from the weekly report."""
-
-    def remain(device: DeviceContext) -> Mapping[str, Any]:
-        return {"native_value": _weekly_battery_field(device, "remain")}
-
-    def consume(device: DeviceContext) -> Mapping[str, Any]:
-        return {"native_value": _weekly_battery_field(device, "consume")}
-
-    def opens(device: DeviceContext) -> Mapping[str, Any]:
-        return {"native_value": _weekly_open_info(device, "total")}
-
-    def users(device: DeviceContext) -> Mapping[str, Any]:
-        return {"native_value": _weekly_open_info(device, "userNum")}
-
-    def period(device: DeviceContext) -> Mapping[str, Any]:
-        value = device.value(_WEEKLY_REPORT_SID, "period")
-        return {"native_value": value if isinstance(value, str) and value else None}
-
-    def per_user(device: DeviceContext) -> Mapping[str, Any]:
-        """Expose the per-member unlock counts documented by the report."""
-        info = device.value(_WEEKLY_REPORT_SID, "openinfo")
-        if not isinstance(info, Mapping):
-            return {"native_value": None}
-        entries = info.get("info")
-        if not isinstance(entries, list):
-            return {"native_value": None}
-        counts: dict[str, int] = {}
-        for entry in entries:
-            if not isinstance(entry, Mapping):
-                continue
-            name = entry.get("nm")
-            if not isinstance(name, str) or not name:
-                continue
-            days = sum(
-                1 for key, value in entry.items() if key.startswith("d") and value
-            )
-            counts[name] = days
-        if not counts:
-            return {"native_value": None}
-        return {
-            "native_value": len(counts),
-            "members": json.dumps(counts, ensure_ascii=False),
-        }
-
-    return [
-        EntitySpec(
-            platform="sensor",
-            key="weekly_battery_remain",
-            name="周报电池剩余",
-            state=remain,
-            metadata={
-                "native_unit_of_measurement": "%",
-                "device_class": "battery",
-                "state_class": "measurement",
-                "entity_category": "diagnostic",
-            },
-        ),
-        EntitySpec(
-            platform="sensor",
-            key="weekly_battery_consume",
-            name="周报电池消耗",
-            state=consume,
-            metadata={
-                "native_unit_of_measurement": "%",
-                "state_class": "measurement",
-                "entity_category": "diagnostic",
-            },
-        ),
-        EntitySpec(
-            platform="sensor",
-            key="weekly_unlocks",
-            name="本周开门次数",
-            state=opens,
-            metadata={"state_class": "measurement"},
-        ),
-        EntitySpec(
-            platform="sensor",
-            key="weekly_unlock_users",
-            name="本周开锁人数",
-            state=users,
-            metadata={"state_class": "measurement"},
-        ),
-        EntitySpec(
-            platform="sensor",
-            key="weekly_period",
-            name="统计周期",
-            state=period,
-            metadata={"entity_category": "diagnostic"},
-        ),
-        EntitySpec(
-            platform="sensor",
-            key="weekly_per_user",
-            name="本周各成员开门天数",
-            state=per_user,
-            metadata={"entity_category": "diagnostic"},
-        ),
-    ]
-
 
 def _firmware_specs(context: DeviceContext) -> list[EntitySpec]:
     """Firmware version of the lock body.

--- a/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
@@ -533,7 +533,291 @@ class ProductKW02Adapter:
             entities.append(_open_direction_spec(read_unlock))
             entities.append(_last_open_method_spec(profile, read_unlock))
             entities.append(_door_alarm_spec(profile))
+        entities.extend(_weekly_report_specs())
+        entities.extend(_firmware_specs(context))
+        entities.extend(_roster_specs(context))
+        entities.extend(_reader_based_specs(context))
         return tuple(entities)
+
+
+# ---------------------------------------------------------------------------
+# Read-only reporting entities.
+#
+# AGS-X10 firmware reports far more than the public Profile declares: the lock
+# pushes 42 services while the Profile documents 21.  The entities below are
+# read-only projections of services the lock was observed to report on a real
+# device; nothing here writes to the lock and no command is offered, so no
+# unverified write can reach the hardware.
+#
+# Wire details confirmed against the lock (deviating from the Profile):
+#   weeklyReport     battery.remain/consume are percentages; openinfo.total is
+#                    the number of unlocks in `period`; openinfo.userNum counts
+#                    distinct users.
+#   update           currentVersion is a firmware string ("AGS-X10 5.0.0.1(SP65C00)").
+#                    The Profile's update.action is deliberately not exposed.
+#   users            userList carries every enrolled member (un = name).
+#   keyOperate       keyName names the credential used last ("人脸 01").
+#   doorEvent        the per-event feed; its userName is the same person the
+#                    event/eventData pair reports.
+#   lastActionTime   time is the last time the lock was operated.
+# ---------------------------------------------------------------------------
+
+_WEEKLY_REPORT_SID = "weeklyReport"
+_UPDATE_SID = "update"
+_USERS_SID = "users"
+_KEY_OPERATE_SID = "keyOperate"
+_DOOR_EVENT_SID = "doorEvent"
+_LAST_ACTION_SID = "lastActionTime"
+_FACES_SID = "faces"
+_FINGERS_SID = "fingers"
+
+
+def _weekly_battery_field(
+    device: DeviceContext,
+    name: str,
+) -> int | float | None:
+    report = device.value(_WEEKLY_REPORT_SID, "battery")
+    if not isinstance(report, Mapping):
+        return None
+    return _number(report.get(name))
+
+
+def _weekly_open_info(
+    device: DeviceContext,
+    name: str,
+) -> int | float | None:
+    info = device.value(_WEEKLY_REPORT_SID, "openinfo")
+    if not isinstance(info, Mapping):
+        return None
+    return _number(info.get(name))
+
+
+def _weekly_report_specs() -> list[EntitySpec]:
+    """Battery trend and unlock statistics from the weekly report."""
+
+    def remain(device: DeviceContext) -> Mapping[str, Any]:
+        return {"native_value": _weekly_battery_field(device, "remain")}
+
+    def consume(device: DeviceContext) -> Mapping[str, Any]:
+        return {"native_value": _weekly_battery_field(device, "consume")}
+
+    def opens(device: DeviceContext) -> Mapping[str, Any]:
+        return {"native_value": _weekly_open_info(device, "total")}
+
+    def users(device: DeviceContext) -> Mapping[str, Any]:
+        return {"native_value": _weekly_open_info(device, "userNum")}
+
+    def period(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_WEEKLY_REPORT_SID, "period")
+        return {"native_value": value if isinstance(value, str) and value else None}
+
+    def per_user(device: DeviceContext) -> Mapping[str, Any]:
+        """Expose the per-member unlock counts documented by the report."""
+        info = device.value(_WEEKLY_REPORT_SID, "openinfo")
+        if not isinstance(info, Mapping):
+            return {"native_value": None}
+        entries = info.get("info")
+        if not isinstance(entries, list):
+            return {"native_value": None}
+        counts: dict[str, int] = {}
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                continue
+            name = entry.get("nm")
+            if not isinstance(name, str) or not name:
+                continue
+            days = sum(
+                1 for key, value in entry.items() if key.startswith("d") and value
+            )
+            counts[name] = days
+        if not counts:
+            return {"native_value": None}
+        return {
+            "native_value": len(counts),
+            "members": json.dumps(counts, ensure_ascii=False),
+        }
+
+    return [
+        EntitySpec(
+            platform="sensor",
+            key="weekly_battery_remain",
+            name="周报电池剩余",
+            state=remain,
+            metadata={
+                "native_unit_of_measurement": "%",
+                "device_class": "battery",
+                "state_class": "measurement",
+                "entity_category": "diagnostic",
+            },
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="weekly_battery_consume",
+            name="周报电池消耗",
+            state=consume,
+            metadata={
+                "native_unit_of_measurement": "%",
+                "state_class": "measurement",
+                "entity_category": "diagnostic",
+            },
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="weekly_unlocks",
+            name="本周开门次数",
+            state=opens,
+            metadata={"state_class": "measurement"},
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="weekly_unlock_users",
+            name="本周开锁人数",
+            state=users,
+            metadata={"state_class": "measurement"},
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="weekly_period",
+            name="统计周期",
+            state=period,
+            metadata={"entity_category": "diagnostic"},
+        ),
+        EntitySpec(
+            platform="sensor",
+            key="weekly_per_user",
+            name="本周各成员开门天数",
+            state=per_user,
+            metadata={"entity_category": "diagnostic"},
+        ),
+    ]
+
+
+def _firmware_specs(context: DeviceContext) -> list[EntitySpec]:
+    """Firmware version of the lock body.
+
+    Read-only on purpose: the Profile's ``update.action`` would let HA start an
+    OTA, which has not been validated on this hardware, so only the reported
+    version is projected.
+    """
+
+    if not context.has_service(_UPDATE_SID):
+        return []
+
+    def version(device: DeviceContext) -> Mapping[str, Any]:
+        value = device.value(_UPDATE_SID, "currentVersion")
+        return {"native_value": value if isinstance(value, str) and value else None}
+
+    return [
+        EntitySpec(
+            platform="sensor",
+            key="firmware_version",
+            name="固件版本",
+            state=version,
+            metadata={"entity_category": "diagnostic"},
+        )
+    ]
+
+
+def _roster_specs(context: DeviceContext) -> list[EntitySpec]:
+    """Enrolled-credential counts, e.g. how many faces or fingerprints exist."""
+
+    specs: list[EntitySpec] = []
+
+    def make_count(sid: str, field: str, key: str, name: str) -> EntitySpec:
+        def state(device: DeviceContext) -> Mapping[str, Any]:
+            raw = device.value(sid, field)
+            if not isinstance(raw, list):
+                return {"native_value": None}
+            return {"native_value": len(raw)}
+
+        return EntitySpec(
+            platform="sensor",
+            key=key,
+            name=name,
+            state=state,
+            metadata={"state_class": "measurement", "entity_category": "diagnostic"},
+        )
+
+    if context.has_service(_USERS_SID):
+        def users(device: DeviceContext) -> Mapping[str, Any]:
+            raw = device.value(_USERS_SID, "userList")
+            if not isinstance(raw, list):
+                return {"native_value": None}
+            names = [
+                str(item.get("un"))
+                for item in raw
+                if isinstance(item, Mapping) and item.get("un")
+            ]
+            return {
+                "native_value": len(names),
+                "members": ",".join(names),
+            }
+
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="user_count",
+                name="用户数",
+                state=users,
+                metadata={"state_class": "measurement"},
+            )
+        )
+    if context.has_service(_FACES_SID):
+        specs.append(make_count(_FACES_SID, "face", "face_count", "人脸数"))
+    if context.has_service(_FINGERS_SID):
+        specs.append(make_count(_FINGERS_SID, "finger", "finger_count", "指纹数"))
+    return specs
+
+
+def _reader_based_specs(context: DeviceContext) -> list[EntitySpec]:
+    """Last-operated metadata reported as plain text."""
+
+    specs: list[EntitySpec] = []
+
+    if context.has_service(_KEY_OPERATE_SID):
+        def key_name(device: DeviceContext) -> Mapping[str, Any]:
+            value = device.value(_KEY_OPERATE_SID, "keyName")
+            return {"native_value": value if isinstance(value, str) and value else None}
+
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="last_key",
+                name="最近使用钥匙",
+                state=key_name,
+            )
+        )
+    if context.has_service(_DOOR_EVENT_SID):
+        def door_user(device: DeviceContext) -> Mapping[str, Any]:
+            value = device.value(_DOOR_EVENT_SID, "userName")
+            return {"native_value": value if isinstance(value, str) and value else None}
+
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="door_event_user",
+                name="最近门事件人员",
+                state=door_user,
+            )
+        )
+    if context.has_service(_LAST_ACTION_SID):
+        def last_action(device: DeviceContext) -> Mapping[str, Any]:
+            value = device.value(_LAST_ACTION_SID, "time")
+            return {"native_value": value if isinstance(value, str) and value else None}
+
+        specs.append(
+            EntitySpec(
+                platform="sensor",
+                key="last_action_time",
+                name="最近操作时间",
+                state=last_action,
+                # The lock reports SmartHome stamps ("20260912T094645Z"), not
+                # ISO 8601, so device_class=timestamp is deliberately omitted:
+                # HA would reject the value and the entity would show unknown.
+                metadata={"entity_category": "diagnostic"},
+            )
+        )
+    return specs
 
 
 ADAPTER = ProductKW02Adapter()


### PR DESCRIPTION
## 概述

AGS-X10 固件实际上报 **42 个服务**，而公开 Profile 只声明 21 个。本 PR 为 `prod_KW02.py` 补上**只读**的上报类实体——这些服务在真机上确有推送，但适配器此前未呈现。

**只增不改**：只在 `entities()` 末尾追加 spec，未修改任何既有逻辑或实体（相对上游 +150 行 / 0 删除）。

## 新增实体（7 个）

| 平台 | 实体 | 来源 |
| --- | --- | --- |
| `sensor` | 固件版本 | `update.currentVersion` |
| `sensor` | 用户数（`members` 属性带名单）| `users.userList` |
| `sensor` | 人脸数 | `faces.face` |
| `sensor` | 指纹数 | `fingers.finger` |
| `sensor` | 最近使用钥匙 | `keyOperate.keyName` |
| `sensor` | 最近门事件人员 | `doorEvent.userName` |
| `sensor` | 最近操作时间 | `lastActionTime.time` |

## 为什么全部只读

- **不加任何命令**：`update.action` 可触发 OTA，但未在真机验证，因此只投影版本号，不提供升级动作。
- 与适配器现有立场一致——注释中已记录 `lockStatus` 虽为 `RW`，但固件接受写入后忽略（ack 成功、门不动），故锁实体保持纯状态读取。本 PR 沿用该原则。

## 真机验证（AGS-X10）

在一台在线门锁上实测，读到的值：

| 实体 | 实测值 |
| --- | --- |
| 固件版本 | `AGS-X10 5.0.0.1(SP65C00)` |
| 用户数 | 10 |
| 人脸数 / 指纹数 | 9 / 12 |
| 最近使用钥匙 | 人脸 01 |
| 最近操作时间 | 20260912T094645Z |

部署后集成无 setup 错误，实体正常生成并取值。

## 需要注意的线上格式

1. **`lastActionTime.time` 使用 SmartHome 时间戳格式**（`20260912T094645Z`），非 ISO 8601，因此**没有**设置 `device_class: timestamp`（否则 HA 会判为非法值并显示 unknown）。
2. 真机服务名与 Profile 存在出入（如 Profile 的 `temporaryCipher`，真机为 `temporaryCiper`），因此这里仍以实机行为为准。

## 未包含

- **`weeklyReport`（周报）**：初版曾包含电池趋势与开门统计，但它是**每周一条的汇总**，既非实时状态、也无法驱动自动化，且与既有的电量/事件实体信息重叠，故已移除，不在本 PR 内。
- **设置类服务**（`securitySetting` / `volumeSetting` / `alarmEventSetting` / `catEyeSetting`）：均为 `RW`，涉及写入，需逐项真机验证后再提。
- `faces` / `fingers` 仅提供数量；明细（`fn` 名称等）未展开，避免一次 PR 引入过多实体。
- `liveVideo`、`familyCare`、`homeGreeting`、`weatherReminder` 等未验证其可读语义，暂不呈现。

## 隐私声明

不含账号、令牌、设备序列号、MAC 及完整 Profile 快照，也不含家庭成员昵称——`用户数` 实体的 `members` 属性在运行时由设备数据填充，本 PR 不记录其内容。