### PR TITLE
feat(media_player): support power, source selection and media metadata

### DIFF
--- a/custom_components/huawei_smarthome/media_player.py
+++ b/custom_components/huawei_smarthome/media_player.py
@@ -21,7 +21,17 @@ class HuaweiAdapterMediaPlayer(AdapterEntityMixin, MediaPlayerEntity):
     def __init__(self, context: Any, spec: Any) -> None:
         self._init_adapter_entity(context, spec)
         features = MediaPlayerEntityFeature(0)
-        for action, feature in (("play", MediaPlayerEntityFeature.PLAY), ("pause", MediaPlayerEntityFeature.PAUSE), ("stop", MediaPlayerEntityFeature.STOP), ("volume", MediaPlayerEntityFeature.VOLUME_SET), ("next", MediaPlayerEntityFeature.NEXT_TRACK), ("previous", MediaPlayerEntityFeature.PREVIOUS_TRACK)):
+        for action, feature in (
+            ("play", MediaPlayerEntityFeature.PLAY),
+            ("pause", MediaPlayerEntityFeature.PAUSE),
+            ("stop", MediaPlayerEntityFeature.STOP),
+            ("volume", MediaPlayerEntityFeature.VOLUME_SET),
+            ("next", MediaPlayerEntityFeature.NEXT_TRACK),
+            ("previous", MediaPlayerEntityFeature.PREVIOUS_TRACK),
+            ("turn_on", MediaPlayerEntityFeature.TURN_ON),
+            ("turn_off", MediaPlayerEntityFeature.TURN_OFF),
+            ("select_source", MediaPlayerEntityFeature.SELECT_SOURCE),
+        ):
             if action in spec.actions:
                 features |= feature
         self._attr_supported_features = features
@@ -32,9 +42,34 @@ class HuaweiAdapterMediaPlayer(AdapterEntityMixin, MediaPlayerEntity):
     def volume_level(self): return self._state_value("volume_level")
     @property
     def is_volume_muted(self): return self._state_value("is_volume_muted")
+    @property
+    def media_title(self): return self._state_value("media_title")
+    @property
+    def media_artist(self): return self._state_value("media_artist")
+    @property
+    def media_album_name(self): return self._state_value("media_album_name")
+    @property
+    def media_image_url(self): return self._state_value("media_image_url")
+    @property
+    def media_series_title(self): return self._state_value("media_series_title")
+    @property
+    def media_season(self): return self._state_value("media_season")
+    @property
+    def media_episode(self): return self._state_value("media_episode")
+    @property
+    def media_position(self): return self._state_value("media_position")
+    @property
+    def media_duration(self): return self._state_value("media_duration")
+    @property
+    def source(self): return self._state_value("source")
+    @property
+    def source_list(self): return self._state_value("source_list")
     async def async_media_play(self): await self._run_action("play", {})
     async def async_media_pause(self): await self._run_action("pause", {})
     async def async_media_stop(self): await self._run_action("stop", {})
     async def async_set_volume_level(self, volume: float): await self._run_action("volume", {"volume": volume})
     async def async_media_next_track(self): await self._run_action("next", {})
     async def async_media_previous_track(self): await self._run_action("previous", {})
+    async def async_turn_on(self): await self._run_action("turn_on", {})
+    async def async_turn_off(self): await self._run_action("turn_off", {})
+    async def async_select_source(self, source: str): await self._run_action("select_source", {"source": source})


### PR DESCRIPTION
## 背景

按维护者在 #48 中的要求拆分：**本 PR 只含媒体平台的框架变更**，电视适配器本身在另一个 PR。

> 麻烦拆一下pr，将媒体平台变更，单独做一个pr。谢谢！
> —— xiasi0 于 #48

## 变更内容

`media_player.py` 原先只支持 `play`/`pause`/`stop`/`volume`/`next`/`previous`，因此适配器**无法表达**电视的电源、输入源，也无法呈现正在播放的内容。本 PR 以**向后兼容**的方式补齐适配器所需的接口。

### 新增动作

每个动作只有在适配器确实提供时才被声明为对应 feature：

| action | feature |
| --- | --- |
| `turn_on` | `TURN_ON` |
| `turn_off` | `TURN_OFF` |
| `select_source` | `SELECT_SOURCE` |

### 新增只读属性

从适配器的 `state` 映射读取：

`media_image_url`、`media_series_title`、`media_season`、`media_episode`、`media_position`、`media_duration`、`source`、`source_list`

### 同时补上基础媒体信息

平台此前**完全没有暴露任何元数据**，所以 `media_title` / `media_artist` / `media_album_name` 也在此列出（取值仍来自适配器）。

## 向后兼容

未提供某个 key 的适配器，该属性读取为 `None`，Home Assistant 视为"无此属性"。仓库内现有的三个 `media_player` 适配器（`prod_x0a2`、`prod_x005`、`prod_x0a3`）**都只声明 play/pause/stop**：

- 它们不提供上述任何新 key → 新属性为空
- 它们不提供 `turn_on`/`turn_off`/`select_source` → 对应 feature 不会被添加，界面上不出现多余按钮

因此行为不变。

## 改动规模

**1 个文件，+36 / -1**（`media_player.py`）。除多行化那个 action→feature 映射表外，均为新增行。

## 验证

- 模块导入正常，`HuaweiAdapterMediaPlayer` 的媒体属性齐全
- 在测试机上部署后，集成加载**无 setup 错误**
- 使用这些新属性的 V0A2 电视适配器（配套 PR）实测正常：`media_title`/`media_episode`/`media_position`/`media_image_url` 均能取值

## 关联

- 配套 PR：V0A2 电视适配器（使用本 PR 新增的属性）。该适配器在缺这些属性时会优雅降级（读取为 None），因此两个 PR 的合并顺序不影响正确性。

## 隐私声明

不含账号、令牌、设备序列号等任何隐私信息。