### PR TITLE
feat(device_adapters): let adapters report events and read service update time

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/api.py
+++ b/custom_components/huawei_smarthome/device_adapters/api.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 StateReader = Callable[["DeviceContext"], Mapping[str, Any]]
 EntityAction = Callable[["DeviceContext", Mapping[str, Any]], Awaitable[None]]
+# Returns the events that are outstanding for the device right now, keyed by
+# event type.  The framework diffs consecutive readings and fires the ones
+# that are new, so the reader stays a pure function like ``StateReader``.
+EventReader = Callable[["DeviceContext"], Mapping[str, Mapping[str, Any]]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +28,10 @@ class EntitySpec:
     state: StateReader
     metadata: Mapping[str, Any] = field(default_factory=dict)
     actions: Mapping[str, EntityAction] = field(default_factory=dict)
+    # Only meaningful for platform="event": lets an adapter report one-shot
+    # occurrences (detections, button presses, door events) that HA
+    # automations can trigger on, instead of only a standing state.
+    events: EventReader | None = None
 
 
 class HuaweiProductAdapter(Protocol):

--- a/custom_components/huawei_smarthome/device_adapters/context.py
+++ b/custom_components/huawei_smarthome/device_adapters/context.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import replace
+from datetime import datetime
 from typing import Any
 
 from ..domain.models import (
     RemoteDeviceDescriptor,
     RemoteServiceState,
     is_older_remote_timestamp,
+    parse_remote_timestamp,
 )
 from ..mqtt.commands import HuaweiCommandGateway
 from ..mqtt.protocol import decode_message
@@ -88,6 +90,25 @@ class DeviceContext:
 
     def service_state(self, sid: str) -> Mapping[str, Any]:
         return dict(self._state.get(sid, {}))
+
+    def service_updated_at(self, sid: str) -> datetime | None:
+        """Return when one service was last updated by the device.
+
+        Some services (camera ``alarmEvent``, lock ``event``, button reports)
+        carry event semantics: the cloud pushes a value once and never sends
+        the cleared one, so the raw state stays at its last value forever.
+        Without the update time an adapter cannot tell "just happened" from
+        "happened days ago", and a state-style entity latches on.
+
+        The timestamp is the device-reported one (MQTT ``ts`` / snapshot
+        ``reported_timestamp``), so it reflects when the device observed the
+        change rather than when HA received it.
+        """
+
+        timestamp = self._timestamps.get(sid)
+        if not timestamp:
+            return None
+        return parse_remote_timestamp(timestamp)
 
     async def async_send_service(
         self,

--- a/custom_components/huawei_smarthome/event.py
+++ b/custom_components/huawei_smarthome/event.py
@@ -23,6 +23,66 @@ class HuaweiAdapterEvent(AdapterEntityMixin, EventEntity):
         if spec.metadata.get("device_class"):
             self._attr_device_class = EventDeviceClass(spec.metadata["device_class"])
         self._attr_event_types = list(spec.metadata.get("event_types", ("event",)))
+        # Latest marker per event type, used to tell what is new.  Adapters
+        # report their outstanding events; the framework fires the difference.
+        self._seen_events: dict[str, str] = {}
+        # The first reading only establishes a baseline.  Whatever the device
+        # last reported happened before Home Assistant started, so firing it
+        # would announce a stale event as if it had just occurred.
+        self._baseline_taken = False
 
     def trigger(self, event_type: str = "event", event_data: dict[str, Any] | None = None) -> None:
         self._trigger_event(event_type, event_data or {})
+
+    def _state_changed(self) -> None:
+        self._fire_new_events()
+        self.async_write_ha_state()
+
+    def _fire_new_events(self) -> None:
+        """Trigger every event the adapter reports as newly outstanding.
+
+        Adapters express one-shot occurrences through ``EntitySpec.events``
+        because the cloud may push an occurrence once and never send the
+        cleared value, so a state-only entity either latches on or loses the
+        occurrence entirely.  Comparing against the previous reading lets the
+        same occurrence fire once without the adapter owning any state.
+
+        The reading is also skipped when it is not newer than the last one, so
+        a re-delivered MQTT message cannot fire a duplicate event.
+        """
+
+        reader = getattr(self._spec, "events", None)
+        if reader is None:
+            return
+        try:
+            current = reader(self._device_context)
+        except Exception:  # adapter errors must never break the HA event loop
+            return
+        if not isinstance(current, dict):
+            return
+        if not self._baseline_taken:
+            self._baseline_taken = True
+            for event_type, data in current.items():
+                self._seen_events[event_type] = _event_marker(data)
+            return
+        for event_type, data in current.items():
+            marker = _event_marker(data)
+            if self._seen_events.get(event_type) == marker:
+                continue
+            self._seen_events[event_type] = marker
+            self.trigger(event_type, dict(data) if isinstance(data, dict) else {})
+
+
+def _event_marker(data: Any) -> str:
+    """Return a value identifying one occurrence of an event.
+
+    ``alarmId`` and ``id`` are the identifiers the cloud already assigns to an
+    occurrence, so they are preferred; anything else falls back to the payload
+    contents, which still distinguishes "a new event" from "the same one".
+    """
+
+    payload = data if isinstance(data, dict) else {}
+    marker = payload.get("alarmId") or payload.get("id")
+    if marker is None:
+        marker = repr(sorted((str(k), str(v)) for k, v in payload.items()))
+    return str(marker)


### PR DESCRIPTION
> 对应 issue #42。此前已在 issue 中讨论过方向，这里给出实现。

## 问题

华为云对**事件型信号**（摄像头 `alarmEvent`、门锁 `event`、按键上报）**只推送一次，从不下发归零值**。当前适配器只能用 `EntitySpec.state` 表达**状态**，于是这类信号无法被正确表达。

### 证据一：仓库里已经有一个失效的 event 实体

`HuaweiAdapterEvent.trigger()` 早就存在，但**全仓库没有任何地方调用它**。而 Home Assistant 的 `EventEntity` **只通过 `_trigger_event()` 触发**，不读取 `state`。

仓库里已经有一个踩到这个坑的适配器——`prod_KW5L.py`：

```python
ha_event_type = None
if event_type == 2 or door_alarm is not None:
    ha_event_type = "alarm"
elif event_type == 1:
    ha_event_type = "record"

return {
    "event_type": ha_event_type or "unknown",     # ← HA 忽略它
    ...
}

entities.append(EntitySpec(platform="event", ...))
```

它的 state 认真计算了事件类型，但**这个 event 实体永远不会有事件**——`event_type` 字段被 HA 丢弃。

（`grep` 确认：45 个适配器中仅此一个使用 `event` 平台，且没有任何适配器使用 `events` 读取器——因为后者尚不存在。）

### 证据二：无法区分"刚发生"与"很久以前"

`DeviceContext` 内部**一直在维护**每个服务的时间戳（MQTT 的 `ts`、快照的 `reported_timestamp`），并用于乱序保护，但**没有对外暴露**。

真机实测（2G4N 摄像头，同一时刻读取）：

```
service_updated_at(carmera)     = 2026-09-12 08:22:38
service_updated_at(alarmEvent)  = 2026-09-12 07:30:57   ← 52 分钟前
service_updated_at(netInfo)     = 2026-09-12 08:22:43
service_updated_at(voip)        = 2026-09-12 08:22:43
```

`alarmEvent` 的值是 52 分钟前的，但纯状态型实体只能把它呈现为"现在有告警"。适配器**没有任何办法**做时效判断。

## 实现

### 1. `EntitySpec.events`（可选读取器）

```python
EventReader = Callable[["DeviceContext"], Mapping[str, Mapping[str, Any]]]

@dataclass(frozen=True, slots=True)
class EntitySpec:
    ...
    events: EventReader | None = None
```

适配器返回**当前未消费的事件**（按事件类型分组，值是属性字典），平台比对相邻两次读取并触发新增的那些。这样：

- 读取器仍是**纯函数**（与 `StateReader` 风格一致），适配器**不需要自己持有状态**
- 用 `alarmId` / `id` 作为去重标记——云本来就给每次发生分配了标识；没有则回退到载荷内容

**首次读取只建立基线**：设备上报的最后一次事件发生在 Home Assistant 启动**之前**，若在启动时触发，用户会看到一条陈旧事件被当作"刚刚发生"。MQTT 重投同一消息会得到相同读取，因此不会重复触发。

### 2. `DeviceContext.service_updated_at(sid)`

暴露已有的内部时间戳，复用 `domain/models.py` 里现成的 `parse_remote_timestamp`（不新造解析逻辑）。有了它，适配器既能做时效判断（如"最近 N 秒内才算有效"的脉冲），也能在实体上标注数据新鲜度。

## 向后兼容

两处均为**可选**：

- 不提供 `events` 的适配器：`reader is None` → 直接返回，行为与现在**完全一致**（`prod_KW5L` 的 event 实体仍是现状，不会因本 PR 而变化或报错）
- 不使用 `service_updated_at` 的适配器：不受影响

改动**3 个文件，+89 / -0**，无删除。

## 验证

**逻辑测试**（模拟平台的比对逻辑，四个场景）：

| 场景 | 期望 | 结果 |
| --- | --- | --- |
| HA 启动后首次读取 | 只建基线，**不触发** | ✅ |
| 设备重发同一告警 | 不重复触发 | ✅ |
| 新告警（`alarmId` 变化）| **触发一次** | ✅ |
| 状态更新但 `alarmId` 不变 | 不重复触发 | ✅ |

**时间戳接口**（真机 2G4N，见上方数据）：`service_updated_at` 返回各服务真实更新时间，`alarmEvent` 正确反映出其 52 分钟前的时效。

**集成端到端**：部署后在测试机加载**无 setup 错误**，222 个实体全部正常（light/switch/sensor/binary_sensor/button/lock/media_player 等）。

## 后续（不在本 PR 内）

本 PR 只提供能力，**不改动任何现有适配器**。若方向认可，可以再提 PR：

- 让 `prod_KW5L` 的 `门锁事件` 真正触发（补 `events` 读取器）
- 让摄像头告警从 `sensor` 升级为「`event` 记录每次发生 + 状态实体」的双层模型（现为 sensor，见已合并的 #40）
- 带 `alarmId` 属性的事件可供自动化做精确去重

这些都会是独立的、可分别评估的改动。

## 隐私声明

不含账号、令牌、设备序列号、MAC 等隐私信息。