### PR TITLE
feat: 从 MQTT 更新分发适配器事件

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/api.py
+++ b/custom_components/huawei_smarthome/device_adapters/api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, TYPE_CHECKING, Protocol
 
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
 
 StateReader = Callable[["DeviceContext"], Mapping[str, Any]]
 EntityAction = Callable[["DeviceContext", Mapping[str, Any]], Awaitable[None]]
+EventDecoder = Callable[
+    ["DeviceContext", str, Mapping[str, Any], str | None],
+    Iterable[tuple[str, Mapping[str, Any]]],
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +28,7 @@ class EntitySpec:
     state: StateReader
     metadata: Mapping[str, Any] = field(default_factory=dict)
     actions: Mapping[str, EntityAction] = field(default_factory=dict)
+    event_decoder: EventDecoder | None = None
 
 
 class HuaweiProductAdapter(Protocol):

--- a/custom_components/huawei_smarthome/device_adapters/context.py
+++ b/custom_components/huawei_smarthome/device_adapters/context.py
@@ -41,6 +41,9 @@ class DeviceContext:
             if service.reported_timestamp
         }
         self._listeners: set[Callable[[], None]] = set()
+        self._service_update_listeners: set[
+            Callable[[str, Mapping[str, Any], str | None], None]
+        ] = set()
 
     @property
     def key(self) -> tuple[str, str]:
@@ -108,6 +111,20 @@ class DeviceContext:
     def remove_state_listener(self, listener: Callable[[], None]) -> None:
         self._listeners.discard(listener)
 
+    def add_service_update_listener(
+        self,
+        listener: Callable[[str, Mapping[str, Any], str | None], None],
+    ) -> None:
+        """Subscribe to accepted live MQTT service updates."""
+
+        self._service_update_listeners.add(listener)
+
+    def remove_service_update_listener(
+        self,
+        listener: Callable[[str, Mapping[str, Any], str | None], None],
+    ) -> None:
+        self._service_update_listeners.discard(listener)
+
     def handle_mqtt_message(self, payload: bytes) -> bool:
         """Handle ACKs and raw device state without interpreting product semantics."""
 
@@ -124,6 +141,7 @@ class DeviceContext:
         changed = self.descriptor.online is not True
         if changed:
             self.descriptor = replace(self.descriptor, online=True)
+        updates: list[tuple[str, Mapping[str, Any], str | None]] = []
         for item in services:
             if not isinstance(item, Mapping):
                 continue
@@ -131,14 +149,20 @@ class DeviceContext:
             data = item.get("data")
             if not isinstance(sid, str) or not isinstance(data, Mapping):
                 continue
+            timestamp = item.get("ts")
+            timestamp = timestamp if isinstance(timestamp, str) else None
+            if not self._should_accept_live_update(sid, data, timestamp):
+                continue
             changed = self._merge_state(
                 sid,
                 data,
-                item.get("ts"),
+                timestamp,
             ) or changed
+            updates.append((sid, dict(data), timestamp))
+        self._notify_service_updates(updates)
         if changed:
             self._notify_state_changed()
-        return changed
+        return changed or bool(updates)
 
     def apply_state_snapshot(
         self,
@@ -178,6 +202,22 @@ class DeviceContext:
     def close(self) -> None:
         self.command_gateway.close()
         self._listeners.clear()
+        self._service_update_listeners.clear()
+
+    def _should_accept_live_update(
+        self,
+        sid: str,
+        data: Mapping[str, Any],
+        timestamp: str | None,
+    ) -> bool:
+        previous_timestamp = self._timestamps.get(sid)
+        if is_older_remote_timestamp(timestamp, previous_timestamp):
+            return False
+        if timestamp and previous_timestamp == timestamp:
+            return False
+        if not timestamp and dict(data) == self._state.get(sid, {}):
+            return False
+        return True
 
     def _merge_state(
         self,
@@ -200,3 +240,11 @@ class DeviceContext:
     def _notify_state_changed(self) -> None:
         for listener in tuple(self._listeners):
             listener()
+
+    def _notify_service_updates(
+        self,
+        updates: list[tuple[str, Mapping[str, Any], str | None]],
+    ) -> None:
+        for sid, data, timestamp in updates:
+            for listener in tuple(self._service_update_listeners):
+                listener(sid, data, timestamp)

--- a/custom_components/huawei_smarthome/event.py
+++ b/custom_components/huawei_smarthome/event.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
@@ -10,6 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity_helpers import AdapterEntityMixin, iter_specs
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -26,3 +30,38 @@ class HuaweiAdapterEvent(AdapterEntityMixin, EventEntity):
 
     def trigger(self, event_type: str = "event", event_data: dict[str, Any] | None = None) -> None:
         self._trigger_event(event_type, event_data or {})
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._device_context.add_service_update_listener(
+            self._service_update_received
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._device_context.remove_service_update_listener(
+            self._service_update_received
+        )
+        await super().async_will_remove_from_hass()
+
+    def _service_update_received(
+        self,
+        sid: str,
+        data: Mapping[str, Any],
+        timestamp: str | None,
+    ) -> None:
+        decoder = self._spec.event_decoder
+        if decoder is None:
+            return
+        try:
+            events = decoder(self._device_context, sid, data, timestamp)
+            for event_type, event_data in events:
+                self.trigger(event_type, dict(event_data))
+        except Exception:  # noqa: BLE001 - adapter events must not break MQTT
+            _LOGGER.exception(
+                "Huawei SmartHome event decoder failed: prod_id=%s "
+                "entity=%s sid=%s",
+                self._device_context.prod_id,
+                self.entity_id,
+                sid,
+            )


### PR DESCRIPTION
## 变更说明

- 为产品适配器新增可选的 `event_decoder` 回调，用于将已接受的 MQTT 服务更新解码为 Home Assistant 事件。
- 事件实体订阅服务更新；解码器失败只记录异常，不中断 MQTT 消息处理。
- 在事件解码前对已接受的实时服务更新去重。

## 关联

- 关联 PR #51：本 PR 采用直接解码 MQTT 服务更新的方案，而非基于状态读取器的轮询比对方案。
- 部分处理 Issue #42：提供适配器事件上报通道；服务更新时间戳的公开接口不在本 PR 范围内。

## 验证

- `git diff --check`