### PR TITLE
feat(device_adapters): fire camera alarms as events on the 2G4N

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_2g4n.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_2g4n.py
@@ -276,6 +276,86 @@ def _alarm_sensor_spec(
     )
 
 
+# The alarm fields this adapter reports, mapped to the event type each one
+# fires.  Home Assistant event types must be stable snake_case tokens.
+_ALARM_EVENTS: tuple[tuple[str, str], ...] = (
+    ("humanBodyAlarm", "human_body"),
+    ("audioAlarm", "audio"),
+    ("videoAlarm", "video"),
+    ("babyCryAlarm", "baby_cry"),
+)
+
+# ``alarmId`` arrives as "<camera id>::<epoch ms>"; the epoch is what actually
+# distinguishes one detection from the next, and the camera id is constant, so
+# the timestamp half is the stable part of the identifier.
+_ALARM_ID_SEPARATOR = "::"
+
+
+def _alarm_event_decoder(
+    device: DeviceContext,
+    sid: str,
+    data: Mapping[str, Any],
+    timestamp: str | None,
+) -> list[tuple[str, Mapping[str, Any]]]:
+    """Turn one ``alarmEvent`` push into Home Assistant events.
+
+    ``alarmEvent`` is a one-shot signal: the cloud pushes it when something is
+    detected and never sends the cleared value.  The sensors declared beside
+    this decoder therefore only describe *what was last reported* and cannot
+    drive an automation that should run on every detection -- a later
+    detection that sets the same field produces no state change at all.
+
+    This decoder supplies the missing half: each accepted push is reported as
+    an event, so an automation can trigger on every occurrence and read
+    ``alarm_id`` to tell them apart.
+    """
+
+    if sid != _ALARM_SID:
+        return []
+
+    alarm_id = data.get("alarmId")
+    alarm_ref = str(alarm_id) if alarm_id is not None else None
+    detected_at = None
+    if isinstance(alarm_id, str) and _ALARM_ID_SEPARATOR in alarm_id:
+        detected_at = alarm_id.rsplit(_ALARM_ID_SEPARATOR, 1)[-1] or None
+
+    events: list[tuple[str, Mapping[str, Any]]] = []
+    for field_name, event_type in _ALARM_EVENTS:
+        # Any field the Profile declares as ``0/1`` may arrive as a bool, an int
+        # or a numeric string, so ``_bool`` is used rather than a truthiness
+        # test that would treat the string "0" as raised.
+        if _bool(data.get(field_name)) is not True:
+            continue
+        # A single push can carry several raised fields (a camera reports
+        # audio and video together), so every raised one is reported; the
+        # shared alarm id keeps them recognisable as one occurrence.
+        events.append(
+            (
+                event_type,
+                {
+                    "alarm_id": alarm_ref,
+                    "detected_at": detected_at,
+                    "received_at": timestamp,
+                    "camera": device.name,
+                },
+            )
+        )
+    return events
+
+
+def _alarm_event_spec() -> EntitySpec:
+    """One event entity that fires for every reported detection."""
+
+    return EntitySpec(
+        platform="event",
+        key="alarm",
+        name="告警事件",
+        state=lambda device: {},
+        metadata={"event_types": [event_type for _, event_type in _ALARM_EVENTS]},
+        event_decoder=_alarm_event_decoder,
+    )
+
+
 def _online_spec() -> EntitySpec:
     """One connectivity sensor backed by the device's online flag."""
 
@@ -318,10 +398,11 @@ class Product2G4NAdapter:
                 entities.append(shoot)
 
         if _has_service(profile, _ALARM_SID):
-            # Reported as sensors, not binary_sensors: the cloud pushes an
-            # alarm once and never sends the cleared value, so a
-            # binary_sensor would stay on forever after the first detection
-            # and could never trigger again.
+            # The sensors describe the last reported alarm state -- they cannot
+            # be binary_sensors (the cloud never sends the cleared value, so a
+            # binary_sensor would latch on after the first detection and never
+            # change again) and they cannot drive an automation that must run on
+            # every detection, because a repeated detection changes nothing.
             entities.append(
                 _alarm_sensor_spec(profile, "humanBodyAlarm", "人形检测")
             )
@@ -334,6 +415,9 @@ class Product2G4NAdapter:
             entities.append(
                 _alarm_sensor_spec(profile, "babyCryAlarm", "婴儿哭声")
             )
+            # The event entity supplies that missing half: it fires on every
+            # accepted alarmEvent push, so automations trigger per detection.
+            entities.append(_alarm_event_spec())
         if _has_service(profile, _VOIP_SID):
             entities.append(_binary_sensor_spec(_VOIP_SID, "calling", "呼叫中"))
             # voip.voipCall (RW) triggers a video call to the phone app; the


### PR DESCRIPTION
## 背景

#54（已合并）提供了 `event_decoder` 钩子。本 PR 是**第一个实际使用它的适配器**——把 2G4N 摄像头的告警从"只有状态"升级为"**状态 + 事件**"。

关联 Issue #42。

## 问题

先前合并的告警传感器（#40）**只能表达"最近一次上报的告警状态"**，无法驱动"每次检测都要执行"的自动化：

- 云端**只推一次**告警，**从不下发归零值**
- 因此**第二次检测即使把同一字段再次置 1，也不会产生任何状态变化** → 自动化不会再次运行

也就是说，`人形检测 = 有人形检测告警` 这个实体虽然真实，但它**天然无法作为重复触发的源**。

## 实现

在四个告警传感器**旁边**新增一个事件实体（`platform="event"`，key `alarm`），通过 `event_decoder` 接收已接受的 `alarmEvent` 推送：

```python
event types: human_body, audio, video, baby_cry
attributes : alarm_id, detected_at, received_at, camera
```

- 一次推送若同时置起多个字段（摄像头常同时上报音频+视频），**每个被置起的字段各触发一个事件**，且**共享同一个 `alarm_id`**，便于识别为同一次发生
- 未置起任何字段的推送**不产生事件**
- 其它服务（如 `carmera`）被忽略
- 实体**仅在设备确实上报 `alarmEvent` 服务时**创建

**传感器保持不动**——事件用于"发生了什么"，状态用于"当前读数"，这是 Home Assistant 的惯用配对。

## 验证

**走真实 MQTT 路径**（`DeviceContext.handle_mqtt_message` → 服务更新监听 → 解码器 → 触发），在真机 2G4N 上实测：

| 输入 | 结果 |
| --- | --- |
| 真实载荷 `{videoAlarm, audioAlarm, humanBodyAlarm}` 同时置起 | **3 个事件**（各带同一 `alarm_id`）|
| 单字段 `humanBodyAlarm=1` | **1 个事件** |
| 所有字段为 0 | **0 个事件** |
| 非告警服务 `carmera` | **0 个事件** |
| 新 `alarmId` | **触发新事件** |

另实测：集成部署后加载**无 setup 错误**，`event.*_告警事件` 实体在 HA 中正常注册。

## 一处需要说明的行为

**同一 `alarm_id` 但时间戳更新的重投会再次触发。**

这是因为 context 层按时间戳判定"这是新的更新"并接受它（相同时间戳会被拒绝），解码器随之再次上报。我认为这符合云端语义（重投即重新通知），且 `alarm_id` 已作为属性提供——**需要严格"每次检测只触发一次"的自动化可以按 `alarm_id` 去重**。这一点已写在提交信息与代码注释中。

## 改动规模

**1 个文件，+88 / -4**（其中 4 行删除为注释改写）。仅 `prod_2g4n.py`，不影响其它适配器。

## 后续可选项（不在本 PR 内）

- 同样为 2GAF 增加告警事件（协议相同；该设备目前对外离线，命令尚未复验）
- 为 `prod_KW5L` 的 `门锁事件` 补 `event_decoder` —— 它现在有 `platform="event"` 实体但从未触发，是同一问题的另一个实例

## 隐私声明

不含账号、令牌、设备序列号、MAC 等隐私信息。