### PR TITLE
feat(device_adapters): fire lock operations as events on the KW02

### DIFF
--- a/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
+++ b/custom_components/huawei_smarthome/device_adapters/prod_KW02.py
@@ -421,6 +421,167 @@ def _event_record(device: DeviceContext) -> Mapping[str, Any]:
     return record
 
 
+def _event_kind(record: Mapping[str, Any]) -> str | None:
+    """Classify one lock event record as unlock / lock / alarm / motion.
+
+    The classification mirrors the adapter's own state entities so an event and
+    its matching sensor can never disagree about what happened.
+
+    Two wire quirks drive the order of the checks:
+
+    * ``event`` is emitted only for credential unlocks and its ``up`` lives in a
+      different code space (201 for a credential unlock, never a Profile value),
+      so an ``up`` the Profile cannot place is not "no event" when the record
+      carries a user name -- it is an unlock.  ``eventData`` remains the
+      authority for operations it does describe.
+    * the observed ``event`` payload for a loitering detection also carried
+      ``up: 201`` while its ``aid`` embedded ``MOTION_DETECTION``, so the aid
+      token is checked first and otherwise such a record would be reported as an
+      unlock.
+    """
+
+    identifier = record.get("aid")
+    if isinstance(identifier, str) and "MOTION_DETECTION" in identifier.upper():
+        return "motion"
+    alarm = _number(record.get(_DOOR_ALARM_FIELD))
+    if alarm is not None and alarm >= 1:
+        return "alarm"
+    operation = _number(record.get(_USER_OPERATION_FIELD))
+    if operation == _OPERATION_RELOCK:
+        return "lock"
+    if _unlock_direction(operation) is not None:
+        return "unlock"
+    # An operation the Profile does not describe, together with a user name,
+    # is the credential-unlock copy of the event.
+    user = record.get("un")
+    if isinstance(user, str) and user.strip():
+        return "unlock"
+    return None
+
+
+def _event_identifier(record: Mapping[str, Any]) -> str | None:
+    """Return the identifier the lock assigns to one occurrence.
+
+    ``event``/``eventData`` carry ``eid``, which increments per event, so it is
+    what actually distinguishes two consecutive unlocks.  The nested
+    ``aid``/``id`` fields are a fallback for revisions that omit ``eid``.
+    """
+
+    for key in ("eid", "aid", "id"):
+        value = record.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def _lock_event_decoder(
+    device: DeviceContext,
+    sid: str,
+    data: Mapping[str, Any],
+    timestamp: str | None,
+) -> list[tuple[str, Mapping[str, Any]]]:
+    """Turn one lock event push into a Home Assistant event.
+
+    The lock pushes every operation once and never sends the cleared value, so
+    the state entities (最近开门方式 / 开门方向 / 最近告警) only describe *what
+    happened last*.  Two consecutive unlocks by the same person through the same
+    method produce no state change at all, which means an automation built on
+    those entities runs once and then stops.
+
+    This decoder supplies the missing half: each accepted push fires an event.
+
+    ``event`` carries the user-facing fields (``un`` = user name, ``cl`` =
+    clock) while ``eventData`` carries the operation and alarm codes, so the two
+    are merged exactly the way ``_event_record`` does for the state readers.
+    """
+
+    if sid not in (_EVENT_SID, _EVENT_DATA_SID):
+        return []
+
+    # Decode THIS push, not the standing record.  ``_event_record`` merges both
+    # services because the state readers want the latest known picture, but an
+    # event must not inherit the previous occurrence: the lock reports a
+    # "door closed" record on ``eventData`` right after an unlock, so merging the
+    # cached half would relabel that unlock as a lock and reuse its id.
+    #
+    # The other service is therefore consulted only for fields this push does
+    # not carry: ``un``/``cl`` arrive on ``event`` while ``up``/``das`` arrive on
+    # ``eventData``, and a push may legitimately carry only one half.
+    def _parsed_payload(value: Any) -> Mapping[str, Any]:
+        if isinstance(value, Mapping):
+            return value
+        if isinstance(value, str) and value:
+            try:
+                parsed = json.loads(value)
+            except ValueError:
+                return {}
+            if isinstance(parsed, Mapping):
+                return parsed
+        return {}
+
+    current: dict[str, Any] = dict(data)
+    if sid == _EVENT_DATA_SID:
+        current.pop(_EVENT_DATA_PAYLOAD_FIELD, None)
+        current.update(_parsed_payload(data.get(_EVENT_DATA_PAYLOAD_FIELD)))
+    elif sid == _EVENT_SID:
+        current.update(device.service_state(_EVENT_DATA_SID))
+        current.pop(_EVENT_DATA_PAYLOAD_FIELD, None)
+        other = _parsed_payload(
+            device.value(_EVENT_DATA_SID, _EVENT_DATA_PAYLOAD_FIELD)
+        )
+        # Only fill in what this push lacks, and never take the *identity* of an
+        # event from the other service.
+        for key, value in other.items():
+            if key in ("eid", "aid", "id", "et"):
+                continue
+            current.setdefault(key, value)
+
+    merged = current
+
+    kind = _event_kind(merged)
+    if kind is None:
+        # Credential management, arming, doorbell and similar records are not
+        # user-visible door events, so they deliberately produce nothing.
+        return []
+
+    operation = _number(merged.get(_USER_OPERATION_FIELD))
+    profile_field = _field(
+        device.profile or {}, _EVENT_SID, _USER_OPERATION_PROFILE_FIELD
+    ) or {}
+    alarm_field = _field(
+        device.profile or {}, _EVENT_SID, _DOOR_ALARM_PROFILE_FIELD
+    ) or {}
+
+    payload: dict[str, Any] = {
+        "event_id": _event_identifier(merged),
+        "user": merged.get("un"),
+        "clock": merged.get("cl"),
+        "occurred_at": merged.get("et") or timestamp,
+        "method": _operation_label(profile_field, operation),
+        "direction": _unlock_direction(operation),
+    }
+    alarm_code = _number(merged.get(_DOOR_ALARM_FIELD))
+    if kind == "alarm":
+        payload["alarm"] = _enum_label(alarm_field, alarm_code)
+    return [(kind, {k: v for k, v in payload.items() if v is not None})]
+
+
+def _lock_event_spec() -> EntitySpec:
+    """One event entity that fires for every unlock, lock and door alarm."""
+
+    return EntitySpec(
+        platform="event",
+        key="lock_event",
+        name="门锁事件",
+        state=lambda device: {},
+        metadata={
+            "event_types": ["unlock", "lock", "alarm", "motion"],
+            "icon": "mdi:door-open",
+        },
+        event_decoder=_lock_event_decoder,
+    )
+
+
 def _unlock_reader() -> Callable[[DeviceContext], Any]:
     """Return a reader that keeps the latest unlock seen by one entity.
 
@@ -533,6 +694,10 @@ class ProductKW02Adapter:
             entities.append(_open_direction_spec(read_unlock))
             entities.append(_last_open_method_spec(profile, read_unlock))
             entities.append(_door_alarm_spec(profile))
+            # The state entities above describe the latest operation; this event
+            # entity fires on every operation, so an automation runs on each
+            # unlock instead of only on the first one.
+            entities.append(_lock_event_spec())
         entities.extend(_firmware_specs(context))
         entities.extend(_roster_specs(context))
         entities.extend(_reader_based_specs(context))


### PR DESCRIPTION
## 背景

沿用 #54 的 `event_decoder` 钩子（#55 是摄像头的应用），本 PR 给 **KW02 门锁**补上事件能力，与摄像头那边保持一致的做法。

关联 Issue #42。

## 问题

KW02 现有的事件类实体（`最近开门方式` / `开门方向` / `最近告警`）**只能表达"最近一次操作"**：

- 门锁**每次操作推一次，从不下发清零**
- 因此**同一个人用同一方式连续两次开门，不会产生任何状态变化** → 基于这些传感器的自动化只会运行一次

## 实现

新增 `lock_event` 事件实体，对每一次被接受的推送触发事件：

| event type | 对应 |
| --- | --- |
| `unlock` | 凭据开锁 / 室内开锁 |
| `lock` | 开锁后自动回锁 |
| `alarm` | 门锁告警（门未关 / 门虚掩 / 低电…）|
| `motion` | 门外逗留检测 |

属性：`event_id`、`user`、`clock`、`occurred_at`、`method`、`direction`、`alarm`

其中 `user` 取自设备上报的 `un` 字段（即 App 中设置的成员昵称）。

**状态实体保持不动**——事件说明"发生了什么"，传感器说明"当前读数"。

## 两个关键实现决定（都由真机数据驱动）

### 1. 解码的是**本次推送**，而不是"当前记录"

门锁在开锁后**紧跟着推一条 eventData（door closed / 回锁）**。如果像状态读取器那样把两个服务缓存合并，这条推送会被**误判成上锁**，并**复用上一个事件的 id**。

实测确实如此——第一版实现把一次开锁解码成了 `lock`，且 `event_id` 取的是另一个事件的值。修正后以本次推送为准，另一服务只用于补齐本次缺失的字段，且**绝不从另一服务取事件身份**。

### 2. 分类顺序尊重两个线上怪癖

- **`event` 只在凭据开锁时发送**，其 `up` 位于**另一套编码空间**（凭据开锁为 201，**从不是 Profile 值**）。因此当 `up` 无法被 Profile 归类、而记录**带有用户名**时，那就是开锁，而不是"无事件"。
- **实测的逗留检测载荷同样带 `up: 201`**，但它的 `aid` 内嵌 `MOTION_DETECTION`。所以**先检查 aid 令牌**，否则逗留检测会被误报为开锁。

## 验证

**真实 AGS-X10，走实际 MQTT 路径**（`handle_mqtt_message` → 服务更新监听 → 解码器）：

| 输入 | 结果 |
| --- | --- |
| 真实 `event` 载荷（`aid=MOTION_DETECTION`）| `motion`（带 user）|
| 真实 `eventData` 载荷（`up=38`）| `lock`（上锁）|
| 凭据开锁（`up=201` + 用户名）| `unlock`（带 user）|
| 指纹开锁（`up=0`）| `unlock` / 指纹开锁 / 室外开门 |
| 室内一握开锁（`up=35`）| `unlock` / 室内一握开锁 / 室内开门 |
| 门未关告警（`das=1`）| `alarm` / 门未关告警 |
| 凭据管理（`up=8` 添加密码）| **无事件** |
| 非事件服务（`lockStatus`）| **无事件** |

另实测：集成加载**无 setup 错误**，`event.*_门锁事件` 实体在 HA 中正常注册（门锁实体由 18 → 19）。

## 改动规模

**1 个文件，+165 行**，仅 `prod_KW02.py`，不改动既有实体与逻辑。

## 后续可选项（不在本 PR 内）

- **`prod_KW5L` 的 `门锁事件` 实体至今从不触发** —— 它有 `platform="event"` 但无 `event_decoder`，与 #55 修好的问题完全同类。我手上没有该型号设备，无法验证，故未改动；若维护者认可，可以按同样模式补上。
- `2GAF` 的告警事件（协议与 2G4N 相同；该设备目前对外离线）

## 隐私声明

不含账号、令牌、设备序列号、MAC，也不含任何家庭成员昵称——文中 `user` 字段一律以占位描述代替。